### PR TITLE
Change default name of SSH pub key

### DIFF
--- a/src/main/java/me/sheimi/sgit/ssh/PrivateKeyUtils.java
+++ b/src/main/java/me/sheimi/sgit/ssh/PrivateKeyUtils.java
@@ -32,7 +32,7 @@ public class PrivateKeyUtils {
 	    try {
 		JSch jsch=new JSch();
 		KeyPair kpair=KeyPair.load(jsch, privateKey.getAbsolutePath());
-		kpair.writePublicKey(new FileOutputStream(publicKey), "sgit");
+		kpair.writePublicKey(new FileOutputStream(publicKey), "mgit");
 		kpair.dispose();
 	    } catch (Exception e) {
 		//TODO 


### PR DESCRIPTION
Noticed that while migrating to MGit