### PR TITLE
Only allow publickey and password SSH authentication options

### DIFF
--- a/src/main/java/me/sheimi/sgit/ssh/SGitSessionFactory.java
+++ b/src/main/java/me/sheimi/sgit/ssh/SGitSessionFactory.java
@@ -20,6 +20,7 @@ public class SGitSessionFactory extends JschConfigSessionFactory {
     @Override
     protected void configure(Host arg0, Session session) {
         session.setConfig("StrictHostKeyChecking", "no");
+        session.setConfig("PreferredAuthentications", "publickey,password");
     }
 
     @Override


### PR DESCRIPTION
This will help resolve issue #33 where GSS-API is offered by the server but not supported by the app.