### PR TITLE
Use ACRA to send emails with uncaught exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile 'org.eclipse.jgit:org.eclipse.jgit:3.7.1.201504261725-r'
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.3'
     compile 'com.scottyab:secure-preferences-lib:0.1.4'
+    compile 'ch.acra:acra:4.9.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
     testCompile 'org.robolectric:shadows-support-v4:3.0'

--- a/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -210,7 +210,7 @@ public class SheimiFragmentActivity extends Activity {
 
     /* View Utils End */
 
-    /* Switch Actvity Animation Start */
+    /* Switch Activity Animation Start */
     public void startActivity(Intent intent) {
         super.startActivity(intent);
         forwardTransition();
@@ -233,7 +233,7 @@ public class SheimiFragmentActivity extends Activity {
         overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_right);
     }
 
-    /* Switch Actvity Animation End */
+    /* Switch Activity Animation End */
 
     /* ImageCache Start */
 

--- a/src/main/java/me/sheimi/android/utils/BasicFunctions.java
+++ b/src/main/java/me/sheimi/android/utils/BasicFunctions.java
@@ -1,19 +1,13 @@
 package me.sheimi.android.utils;
 
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.util.Log;
-import android.widget.Toast;
+import com.nostra13.universalimageloader.core.ImageLoader;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 
 import me.sheimi.android.activities.SheimiFragmentActivity;
-import me.sheimi.sgit.R;
 import timber.log.Timber;
-
-import com.nostra13.universalimageloader.core.ImageLoader;
 
 /**
  * Created by sheimi on 8/19/13.
@@ -41,7 +35,7 @@ public class BasicFunctions {
             return hexString.toString();
 
         } catch (NoSuchAlgorithmException e) {
-            BasicFunctions.showException(e);
+            Timber.e(e);
         }
         return "";
     }
@@ -66,38 +60,4 @@ public class BasicFunctions {
     public static ImageLoader getImageLoader() {
         return getActiveActivity().getImageLoader();
     }
-
-    public static void showException(Throwable t) {
-        Timber.e(t, "showing exception");
-        SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
-        activity.showToastMessage(t.getMessage());
-        t.printStackTrace();
-    }
-
-    public static void showException(Throwable t, int res) {
-        Timber.e(t, "showing exception");
-        SheimiFragmentActivity activity = BasicFunctions.getActiveActivity();
-        StackTraceElement[] ste = t.getStackTrace();
-        String str = (t.getCause() != null) ? t.getCause().getMessage()+"\n" : "\n";
-        for (int i=0; i < ste.length; i++){
-            str += ste[i].toString()+"\n";
-        }
-        final String str2 = str;
-        activity.showMessageDialog(R.string.dialog_show_invalid_remote, str2, R.string.action_send_report, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialogInterface, int i) {
-                Intent intent = new Intent(Intent.ACTION_SEND);
-                intent.setType("message/rfc822");
-                intent.putExtra(Intent.EXTRA_EMAIL  , new String[]{getActiveActivity().getString(R.string.report_mail)});
-                intent.putExtra(Intent.EXTRA_SUBJECT, getActiveActivity().getString(R.string.dialog_show_invalid_remote));
-                intent.putExtra(Intent.EXTRA_TEXT, str2);
-                try {
-                    getActiveActivity().startActivity(Intent.createChooser(intent, "Send mail..."));
-                } catch (android.content.ActivityNotFoundException ex) {
-                    Toast.makeText(getActiveActivity(), "There are no email clients installed.", Toast.LENGTH_SHORT).show();
-                }
-            }
-        });
-    }
-
 }

--- a/src/main/java/me/sheimi/android/utils/FsUtils.java
+++ b/src/main/java/me/sheimi/android/utils/FsUtils.java
@@ -147,17 +147,11 @@ public class FsUtils {
             mimeType = getMimeType(uri.toString());
         }
         intent.setDataAndType(uri, mimeType);
-        try {
-            BasicFunctions.getActiveActivity().startActivity(
-                    Intent.createChooser(
-                            intent,
-                            BasicFunctions.getActiveActivity().getString(
-                                    R.string.label_choose_app_to_open)));
-        } catch (ActivityNotFoundException e) {
-            BasicFunctions.showException(e, R.string.error_no_open_app);
-        } catch (Throwable e) {
-            BasicFunctions.showException(e, R.string.error_can_not_open_file);
-        }
+        BasicFunctions.getActiveActivity().startActivity(
+                Intent.createChooser(
+                        intent,
+                        BasicFunctions.getActiveActivity().getString(
+                                R.string.label_choose_app_to_open)));
     }
 
     public static void deleteFile(File file) {

--- a/src/main/java/me/sheimi/sgit/SGitApplication.java
+++ b/src/main/java/me/sheimi/sgit/SGitApplication.java
@@ -3,8 +3,10 @@ package me.sheimi.sgit;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 
+import org.acra.ACRA;
+import org.acra.ReportingInteractionMode;
+import org.acra.annotation.ReportsCrashes;
 import org.eclipse.jgit.transport.CredentialsProvider;
 
 import me.sheimi.android.utils.SecurePrefsException;
@@ -12,8 +14,13 @@ import me.sheimi.android.utils.SecurePrefsHelper;
 import timber.log.Timber;
 
 /**
- *
+ * Custom Application Singleton
  */
+@ReportsCrashes(
+    mailTo = "mgit@manichord.com",
+    mode = ReportingInteractionMode.TOAST,
+    resToastText = R.string.crash_toast_text // optional, displayed as soon as the crash occurs, before collecting data which can take a few seconds
+)
 public class SGitApplication extends Application {
 
     private static Context mContext;
@@ -27,9 +34,6 @@ public class SGitApplication extends Application {
 
         if (BuildConfig.DEBUG) {
             Timber.plant(new Timber.DebugTree());
-        } else {
-            //TODO: add production crash reporting
-            //Timber.plant(new CrashReportingTree());
         }
 
         mContext = getApplicationContext();
@@ -41,6 +45,16 @@ public class SGitApplication extends Application {
             Timber.e(e);
         }
     }
+
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+
+        // The following line triggers the initialization of ACRA
+        ACRA.init(this);
+    }
+
 
     public SecurePrefsHelper getSecurePrefsHelper() {
         return mSecPrefs;

--- a/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
@@ -248,9 +248,7 @@ public class ViewFileActivity extends SheimiFragmentActivity {
                     startActivity(chooserIntent);
                     forwardTransition();
                 } catch (ActivityNotFoundException e) {
-                    BasicFunctions.showException(e, R.string.error_no_edit_app);
-                } catch (Throwable e) {
-                    BasicFunctions.showException(e);
+                    showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
                 }
                 break;
             case R.id.action_edit:

--- a/src/main/java/me/sheimi/sgit/activities/delegate/actions/AddRemoteAction.java
+++ b/src/main/java/me/sheimi/sgit/activities/delegate/actions/AddRemoteAction.java
@@ -7,6 +7,8 @@ import me.sheimi.sgit.R;
 import me.sheimi.sgit.activities.RepoDetailActivity;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
+import timber.log.Timber;
+
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.view.LayoutInflater;
@@ -25,14 +27,11 @@ public class AddRemoteAction extends RepoAction {
         mActivity.closeOperationDrawer();
     }
 
-    public void addToRemote(String name, String url) {
-        try {
-            mRepo.setRemote(name, url);
-            mRepo.updateRemote();
-            mActivity.showToastMessage(R.string.success_remote_added);
-        } catch (IOException e) {
-            BasicFunctions.showException(e);
-        }
+    public void addToRemote(String name, String url) throws IOException {
+        mRepo.setRemote(name, url);
+        mRepo.updateRemote();
+        mActivity.showToastMessage(R.string.success_remote_added);
+
     }
 
     public void showAddRemoteDialog() {
@@ -53,7 +52,13 @@ public class AddRemoteAction extends RepoAction {
                                     DialogInterface dialogInterface, int i) {
                                 String name = remoteName.getText().toString();
                                 String url = remoteUrl.getText().toString();
-                                addToRemote(name, url);
+                                try {
+                                    addToRemote(name, url);
+                                } catch (IOException e) {
+                                    Timber.e(e);
+                                    mActivity.showMessageDialog(R.string.dialog_error_title,
+                                        mActivity.getString(R.string.error_something_wrong));
+                                }
                             }
                         })
                 .setNegativeButton(R.string.label_cancel,

--- a/src/main/java/me/sheimi/sgit/activities/delegate/actions/NewFileAction.java
+++ b/src/main/java/me/sheimi/sgit/activities/delegate/actions/NewFileAction.java
@@ -1,9 +1,12 @@
 package me.sheimi.sgit.activities.delegate.actions;
 
+import java.io.IOException;
+
 import me.sheimi.android.activities.SheimiFragmentActivity.OnEditTextDialogClicked;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.activities.RepoDetailActivity;
 import me.sheimi.sgit.database.models.Repo;
+import timber.log.Timber;
 
 public class NewFileAction extends RepoAction {
 
@@ -18,7 +21,13 @@ public class NewFileAction extends RepoAction {
                 new OnEditTextDialogClicked() {
                     @Override
                     public void onClicked(String text) {
-                        mActivity.getFilesFragment().newFile(text);
+                        try {
+                            mActivity.getFilesFragment().newFile(text);
+                        } catch (IOException e) {
+                            Timber.e(e);
+                            mActivity.showMessageDialog(R.string.dialog_error_title,
+                                mActivity.getString(R.string.error_something_wrong));
+                        }
                     }
                 });
         mActivity.closeOperationDrawer();

--- a/src/main/java/me/sheimi/sgit/activities/delegate/actions/RemoveRemoteAction.java
+++ b/src/main/java/me/sheimi/sgit/activities/delegate/actions/RemoveRemoteAction.java
@@ -18,6 +18,7 @@ import me.sheimi.sgit.R;
 import me.sheimi.sgit.activities.RepoDetailActivity;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
+import timber.log.Timber;
 
 public class RemoveRemoteAction extends RepoAction {
 
@@ -39,13 +40,9 @@ public class RemoveRemoteAction extends RepoAction {
         mActivity.closeOperationDrawer();
     }
 
-    public static void removeRemote(Repo repo, RepoDetailActivity activity, String remote) {
-        try {
-            repo.removeRemote(remote);
-            activity.showToastMessage(R.string.success_remote_removed);
-        } catch (IOException e) {
-            BasicFunctions.showException(e);
-        }
+    public static void removeRemote(Repo repo, RepoDetailActivity activity, String remote) throws IOException {
+        repo.removeRemote(remote);
+        activity.showToastMessage(R.string.success_remote_removed);
     }
 
     public static class RemoveRemoteDialog extends SheimiDialogFragment {
@@ -80,7 +77,12 @@ public class RemoveRemoteAction extends RepoAction {
                 public void onItemClick(AdapterView<?> parent, View view,
                                         int position, long id) {
                     String remote = mAdapter.getItem(position);
-                    removeRemote(mRepo, mActivity, remote);
+                    try {
+                        removeRemote(mRepo, mActivity, remote);
+                    } catch (IOException e) {
+                        Timber.e(e);
+                        mActivity.showMessageDialog(R.string.dialog_error_title, getString(R.string.error_something_wrong));
+                    }
                     dismiss();
                 }
             });

--- a/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -3,6 +3,7 @@ package me.sheimi.sgit.database.models;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -328,9 +329,8 @@ public class Repo implements Comparable<Repo>, Serializable {
     public String getBranchName() {
         try {
             return getGit().getRepository().getFullBranch();
-        } catch (IOException e) {
-            BasicFunctions.showException(e);
-        } catch (StopTaskException e) {
+        } catch (IOException|StopTaskException e) {
+            Timber.e(e, "error getting branch name");
         }
         return "";
     }
@@ -354,9 +354,8 @@ public class Repo implements Comparable<Repo>, Serializable {
                 branchList.add(name);
             }
             return branchList.toArray(new String[0]);
-        } catch (GitAPIException e) {
-            BasicFunctions.showException(e);
-        } catch (StopTaskException e) {
+        } catch (GitAPIException|StopTaskException e) {
+            Timber.e(e);
         }
         return new String[0];
     }
@@ -368,9 +367,8 @@ public class Repo implements Comparable<Repo>, Serializable {
             if (!it.hasNext())
                 return null;
             return it.next();
-        } catch (GitAPIException e) {
-            BasicFunctions.showException(e);
-        } catch (StopTaskException e) {
+        } catch (GitAPIException|StopTaskException e) {
+            Timber.e(e);
         }
         return null;
     }
@@ -396,9 +394,8 @@ public class Repo implements Comparable<Repo>, Serializable {
         try {
             List<Ref> localRefs = getGit().branchList().call();
             return localRefs;
-        } catch (GitAPIException e) {
-            BasicFunctions.showException(e);
-        } catch (StopTaskException e) {
+        } catch (GitAPIException|StopTaskException e) {
+            Timber.e(e);
         }
         return new ArrayList<Ref>();
     }
@@ -412,9 +409,8 @@ public class Repo implements Comparable<Repo>, Serializable {
                 tags[i] = refs.get(i).getName();
             }
             return tags;
-        } catch (GitAPIException e) {
-            BasicFunctions.showException(e);
-        } catch (StopTaskException e) {
+        } catch (GitAPIException|StopTaskException e) {
+            Timber.e(e);
         }
         return new String[0];
     }
@@ -523,12 +519,8 @@ public class Repo implements Comparable<Repo>, Serializable {
             File repoFile = getDir();
             mGit = Git.open(repoFile);
             return mGit;
-        } catch (RepositoryNotFoundException e) {
-            BasicFunctions
-                    .showException(e, R.string.error_repository_not_found);
-            throw new StopTaskException();
         } catch (IOException e) {
-            BasicFunctions.showException(e);
+            Timber.e(e);
             throw new StopTaskException();
         }
     }

--- a/src/main/java/me/sheimi/sgit/fragments/FilesFragment.java
+++ b/src/main/java/me/sheimi/sgit/fragments/FilesFragment.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 
+import me.sheimi.android.activities.SheimiFragmentActivity;
 import me.sheimi.android.activities.SheimiFragmentActivity.OnBackClickListener;
 import me.sheimi.android.utils.BasicFunctions;
 import me.sheimi.android.utils.FsUtils;
@@ -12,6 +13,9 @@ import me.sheimi.sgit.activities.ViewFileActivity;
 import me.sheimi.sgit.adapters.FilesListAdapter;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.dialogs.RepoFileOperationDialog;
+import timber.log.Timber;
+
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -93,7 +97,13 @@ public class FilesFragment extends RepoDetailFragment {
                             getRawActivity().startActivity(intent);
                             return;
                         }
-                        FsUtils.openFile(file);
+                        try {
+                            FsUtils.openFile(file);
+                        } catch (ActivityNotFoundException e) {
+                            Timber.e(e);
+                            ((SheimiFragmentActivity)getActivity()).showMessageDialog(R.string.dialog_error_title,
+                                getString(R.string.error_can_not_open_file));
+                        }
                     }
                 });
 
@@ -174,18 +184,14 @@ public class FilesFragment extends RepoDetailFragment {
      *
      * @param name
      */
-    public void newFile(String name) {
+    public void newFile(String name) throws IOException {
         File file = new File(mCurrentDir, name);
         if (file.exists()) {
             showToastMessage(R.string.alert_file_exists);
             return;
         }
-        try {
-            file.createNewFile();
-            setCurrentDir(mCurrentDir);
-        } catch (IOException e) {
-            BasicFunctions.showException(e);
-        }
+        file.createNewFile();
+        setCurrentDir(mCurrentDir);
     }
 
     @Override

--- a/src/main/java/me/sheimi/sgit/fragments/ViewFileFragment.java
+++ b/src/main/java/me/sheimi/sgit/fragments/ViewFileFragment.java
@@ -26,6 +26,7 @@ import me.sheimi.android.utils.CodeGuesser;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.activities.ViewFileActivity;
+import timber.log.Timber;
 
 /**
  * Created by phcoder on 09.12.15.
@@ -158,11 +159,9 @@ public class ViewFileFragment extends BaseFragment {
                     try {
                         FileUtils.writeStringToFile(mFile, content);
                     } catch (IOException e) {
-                        BasicFunctions.showException(e,
-                                R.string.alert_save_failed);
+                        showUserError(e, R.string.alert_save_failed);
                     }
                     getActivity().runOnUiThread(new Runnable() {
-
                         @Override
                         public void run() {
                             loadFileContent();
@@ -182,7 +181,7 @@ public class ViewFileFragment extends BaseFragment {
                     try {
                         mCode = FileUtils.readFileToString(mFile);
                     } catch (IOException e) {
-                        BasicFunctions.showException(e);
+                        showUserError(e, R.string.error_can_not_open_file);
                     }
                     display();
                 }
@@ -247,4 +246,15 @@ public class ViewFileFragment extends BaseFragment {
         };
     }
 
+
+    private void showUserError(Throwable e, final int errorMessageId) {
+        Timber.e(e);
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                ((SheimiFragmentActivity)getActivity()).
+                    showMessageDialog(R.string.dialog_error_title, getString(errorMessageId));
+            }
+        });
+    }
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/SheimiAsyncTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/SheimiAsyncTask.java
@@ -1,6 +1,5 @@
 package me.sheimi.sgit.repo.tasks;
 
-import me.sheimi.android.utils.BasicFunctions;
 import android.os.AsyncTask;
 
 public abstract class SheimiAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
@@ -15,14 +14,6 @@ public abstract class SheimiAsyncTask<A, B, C> extends AsyncTask<A, B, C> {
     protected void setException(Throwable e, int errorRes) {
         mException = e;
         mErrorRes = errorRes;
-    }
-
-    protected void showError() {
-        if (mErrorRes != 0) {
-            BasicFunctions.showException(mException, mErrorRes);
-        } else if (mException != null) {
-            BasicFunctions.showException(mException);
-        }
     }
 
     private boolean mIsCanceled = false;

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoOpTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoOpTask.java
@@ -23,7 +23,6 @@ public abstract class RepoOpTask extends SheimiAsyncTask<Void, String, Boolean> 
         super.onPostExecute(isSuccess);
         mRepo.removeTask(this);
         if (!isSuccess && !isTaskCanceled()) {
-            showError();
             return;
         }
         if (isSuccess && mSuccessMsg != 0) {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="default_text">Default Text</string>
     <string name="title_clone_repo">Clone Repository</string>
     <string name="preference_file_key" translatable="false">com.manichord.mgit</string>
-    <string name="report_mail">mgit@manichord.com</string>
 
     <!-- action -->
     <string name="action_search">Search</string>
@@ -124,6 +123,7 @@
     <string name="dialog_show_invalid_remote">Invalid remote report</string>
     <string name="dialog_not_supported">Not Supported</string>
     <string name="dialog_not_supported_msg">This feature is not supported on your device, please see the manual for more details.</string>
+    <string name="dialog_error_title">Error occurred</string>
 
 
     <!-- Others -->
@@ -169,4 +169,7 @@
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>
     <string name="action_add_private_key">Add Private Key</string>
+
+    <!-- Crash reporting via ACRA -->
+    <string name="crash_toast_text">MGit error - gathering data to email a crash report</string>
 </resources>


### PR DESCRIPTION
Remove previous hand-rolled method to show users exceptions, instead use
ACRA to handle uncaught exceptions and send them via std send-email intent.
This refactor also ensures that exceptions are only caught within UI code,
where its reasonable to have code handle them by displaying error dialogs
to the user.