### PR TITLE
keyboard shortcuts

### DIFF
--- a/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -1,18 +1,10 @@
 package me.sheimi.android.activities;
 
-import java.io.File;
-
-import me.sheimi.android.utils.BasicFunctions;
-import me.sheimi.android.utils.Profile;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.SGitApplication;
-import me.sheimi.sgit.dialogs.DummyDialogListener;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -25,6 +17,13 @@ import com.nostra13.universalimageloader.core.DisplayImageOptions;
 import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 import com.nostra13.universalimageloader.utils.StorageUtils;
+
+import java.io.File;
+
+import me.sheimi.android.utils.BasicFunctions;
+import me.sheimi.android.utils.Profile;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.dialogs.DummyDialogListener;
 
 public class SheimiFragmentActivity extends Activity {
 

--- a/src/main/java/me/sheimi/sgit/activities/RepoDetailActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/RepoDetailActivity.java
@@ -228,18 +228,38 @@ public class RepoDetailActivity extends SheimiFragmentActivity {
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
-            int position = mViewPager.getCurrentItem();
-            OnBackClickListener onBackClickListener = mTabItemPagerAdapter
-                    .getItem(position).getOnBackClickListener();
-            if (onBackClickListener != null) {
-                if (onBackClickListener.onClick())
-                    return true;
-            }
-            finish();
-            return true;
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_BACK:
+            case KeyEvent.KEYCODE_DEL:
+                int position = mViewPager.getCurrentItem();
+                OnBackClickListener onBackClickListener = mTabItemPagerAdapter
+                        .getItem(position).getOnBackClickListener();
+                if (onBackClickListener != null) {
+                    if (onBackClickListener.onClick())
+                        return true;
+                }
+                finish();
+                return true;
+            case KeyEvent.KEYCODE_F:
+                mViewPager.setCurrentItem(FILES_FRAGMENT_INDEX);
+                return true;
+            case KeyEvent.KEYCODE_C:
+                mViewPager.setCurrentItem(COMMITS_FRAGMENT_INDEX);
+                return true;
+            case KeyEvent.KEYCODE_S:
+                mViewPager.setCurrentItem(STATUS_FRAGMENT_INDEX);
+                return true;
+
+            case KeyEvent.KEYCODE_H:
+                showKeyboardShortcutsHelpOverlay();
+                return true;
+            default:
+                return super.onKeyUp(keyCode, event);
         }
-        return false;
+    }
+
+    private void showKeyboardShortcutsHelpOverlay() {
+        //TODO
     }
 
     public void error() {

--- a/src/main/java/me/sheimi/sgit/activities/RepoDetailActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/RepoDetailActivity.java
@@ -249,9 +249,10 @@ public class RepoDetailActivity extends SheimiFragmentActivity {
             case KeyEvent.KEYCODE_S:
                 mViewPager.setCurrentItem(STATUS_FRAGMENT_INDEX);
                 return true;
-
-            case KeyEvent.KEYCODE_H:
-                showKeyboardShortcutsHelpOverlay();
+            case KeyEvent.KEYCODE_SLASH:
+                if (event.isShiftPressed()) {
+                    showKeyboardShortcutsHelpOverlay();
+                }
                 return true;
             default:
                 return super.onKeyUp(keyCode, event);
@@ -259,7 +260,7 @@ public class RepoDetailActivity extends SheimiFragmentActivity {
     }
 
     private void showKeyboardShortcutsHelpOverlay() {
-        //TODO
+        showMessageDialog(R.string.dialog_keymap_title, getString(R.string.dialog_keymap_mesg));
     }
 
     public void error() {

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -124,7 +124,8 @@
     <string name="dialog_not_supported">Not Supported</string>
     <string name="dialog_not_supported_msg">This feature is not supported on your device, please see the manual for more details.</string>
     <string name="dialog_error_title">Error occurred</string>
-
+    <string name="dialog_keymap_title">Shortcut Keys</string>
+    <string name="dialog_keymap_mesg"> C - Commits\n F- Files\n S- Status\n ? - Help\n</string>
 
     <!-- Others -->
     <string name="pull_msg_init">Pulling … </string>


### PR DESCRIPTION
Add some initial keyboard shortcuts for the repo details screen, to make navigating between tabs easier on non-touch devices.

Fixes: #9 