### PR TITLE
improve clone dialog ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # MGit
 
-It is a Git client for Android.
-It is [free/libre software](https://www.gnu.org/philosophy/free-sw.html).
+MGit is a Git client Android App.
 
 This is a continuation of [the SGit project](https://github.com/sheimi/SGit).
 
@@ -23,24 +22,25 @@ This is a continuation of [the SGit project](https://github.com/sheimi/SGit).
 * Browse files
 * Browse commit messages (short)
 * Checkout branches and tags
-* HTTP/HTTPS/SSH are supported (SSH without private key passphrase)
+* HTTP/HTTPS/SSH are supported (including SSH with private key passphrase)
 * Username/Password authentication is supported
 * Search local repositories
-* Private keys management
+* Private key management
 * Manually choose code language
-* `git diff` between commits (to be enhanced)
-* Import copied repositories (that is, you can copy a repository from computer and import to MGit)
+* `git diff` between commits
+* Import existing repositories (that is, you can copy a repository from computer and import to MGit)
 * Checkout remote branches
 * Merge branches
 * Push merged content
-* Edit file (you must have some app that can edit file)
-* Commit and push changed files (commit all changes)
+* Edit file (built-in editor or external app that can edit the given file type)
+* Commit and push changed files
 * Committer information
 * Prompt for password
-* Choose not to save password and username (will not be saved in disk but may be temporarily saved in memory)
+* *Option* to save username/password
 * `git status`
 * Cancel when cloning
 * Add modified file to stage
+* View state of staged files (aka index)
 * `git rebase`
 * `git cherrypick`
 * `git checkout <file>` (reset changes of a file)
@@ -52,19 +52,18 @@ This is a continuation of [the SGit project](https://github.com/sheimi/SGit).
 
 ### Clone a remote repository
 
-1. Click on the *+* icon to add a new repository.
-2. Enter remote URL (see URL format below).
-3. Enter local repository name - note that this is not a full path since MGit stores all repositories in the same directory on the mobile device.
-4. Username - username to use to clone the remote repo.
-5. Password - password to use to clone the remote repo.
-6. Click the *Clone* button.
-7. If all the credentials are correct, MGit will download the repository (all branches) to your device.
+1. Click on the `+` icon to add a new repository
+2. Enter remote URL (see URL format below)
+3. Enter local repository name - note that this is **not** the full path, as MGit stores all  
+repositories in the same local directory (can be changed in MGit settings)
+4. Click the `Clone` button
+5. If required, you will be prompted for credentials to connect to the remote repo. MGit will download the repository (all branches) to your device
 
 ### Create a local repository
-1. Click on the *+* icon to add a new repository.
-2. Click on *Init Local* to create a local repository.
-3. Enter the name for this repository when prompted.
-4. A local repo will be created.
+1. Click on the `+` icon to add a new repository
+2. Click on `Init Local` to create a local repository
+3. Enter the name for this repository when prompted
+4. A local empty repo will be created
 
 ### URL format
 
@@ -78,16 +77,19 @@ This is a continuation of [the SGit project](https://github.com/sheimi/SGit).
 
 * HTTP(S) URL: `https://server_name/path/to/repo`
 
-## To Do List
+## ToDo List
 
-[Future enhancements are tracked on Github](https://github.com/maks/MGit/issues).
+[Future enhancements and bugs are tracked here on Github](https://github.com/maks/MGit/issues).
 
 ## License
 
 See [GPLv3](./LICENSE)
 
+All code written by `maks@manichord.com` can at your option also be used under the [MIT license](https://en.wikipedia.org/wiki/MIT_License).
+
 ## Help
 
 If you want to help improve this project, contributions, especially translations are very welcome.
 
-Fork from this repo, create a new branch, commit your changes and then send a pull request against the **master** branch of this repo.
+Fork from this repo, create a new branch, commit your changes and then send a pull request against 
+the **master** branch of this repo.

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ android {
         versionName "1.5.2"
     }
 
+    dataBinding {
+        enabled = true
+    }
+
     lintOptions {
         abortOnError false
     }

--- a/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -23,7 +23,6 @@ import java.io.File;
 import me.sheimi.android.utils.BasicFunctions;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.sgit.R;
-import me.sheimi.sgit.database.RepoContract;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
 
 public class SheimiFragmentActivity extends Activity {
@@ -177,17 +176,6 @@ public class SheimiFragmentActivity extends Activity {
                         new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialogInterface, int i) {
-
-                                // TODO: save password, but to do that need to have an API on the repo object
-                                // instead of exposing direct access to sqlite db
-//                                if (savePassword) {
-//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
-//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
-//                                } else {
-//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
-//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
-//                                }
-
                                 onPasswordEntered.onClicked(username.getText()
                                         .toString(), password.getText()
                                         .toString(), checkBox.isChecked());

--- a/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -24,6 +24,7 @@ import me.sheimi.android.utils.BasicFunctions;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
+import me.sheimi.sgit.repo.tasks.repo.RepoRemoteOpTask;
 
 public class SheimiFragmentActivity extends Activity {
 
@@ -200,7 +201,19 @@ public class SheimiFragmentActivity extends Activity {
         void onClicked(String text);
     }
 
+    /**
+     * Callback interface to receive credentials entered via UI by the user after being prompted
+     * in the UI in order to connect to a remote repo
+     */
     public static interface OnPasswordEntered {
+
+        /**
+         * Handle retrying a Remote Repo task after user supplies requested credentials
+         *
+         * @param username
+         * @param password
+         * @param savePassword
+         */
         void onClicked(String username, String password, boolean savePassword);
 
         void onCanceled();

--- a/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -23,6 +23,7 @@ import java.io.File;
 import me.sheimi.android.utils.BasicFunctions;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.RepoContract;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
 
 public class SheimiFragmentActivity extends Activity {
@@ -175,8 +176,18 @@ public class SheimiFragmentActivity extends Activity {
                 .setPositiveButton(R.string.label_done,
                         new DialogInterface.OnClickListener() {
                             @Override
-                            public void onClick(
-                                    DialogInterface dialogInterface, int i) {
+                            public void onClick(DialogInterface dialogInterface, int i) {
+
+                                // TODO: save password, but to do that need to have an API on the repo object
+                                // instead of exposing direct access to sqlite db
+//                                if (savePassword) {
+//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
+//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
+//                                } else {
+//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
+//                                    values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
+//                                }
+
                                 onPasswordEntered.onClicked(username.getText()
                                         .toString(), password.getText()
                                         .toString(), checkBox.isChecked());

--- a/src/main/java/me/sheimi/sgit/activities/explorer/ImportRepositoryActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/explorer/ImportRepositoryActivity.java
@@ -97,17 +97,9 @@ public class ImportRepositoryActivity extends FileExplorerActivity {
 
     private void createExternalGitRepo() {
         File current = getCurrentDir();
-        String local = Repo.EXTERNAL_PREFIX + current;
-        ContentValues values = new ContentValues();
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, local);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL,
-                "local repository");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
-                RepoContract.REPO_STATUS_NULL);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
-        long id = RepoDbManager.insertRepo(values);
-        Repo repo = Repo.getRepoById(id);
+        String localPath = Repo.EXTERNAL_PREFIX + current;
+
+        Repo repo = Repo.createRepo(localPath, "local repository");
 
         InitLocalTask task = new InitLocalTask(repo);
         task.executeTask();

--- a/src/main/java/me/sheimi/sgit/activities/explorer/ImportRepositoryActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/explorer/ImportRepositoryActivity.java
@@ -107,7 +107,7 @@ public class ImportRepositoryActivity extends FileExplorerActivity {
         values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
         values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
         long id = RepoDbManager.insertRepo(values);
-        Repo repo = Repo.getRepoById(this, id);
+        Repo repo = Repo.getRepoById(id);
 
         InitLocalTask task = new InitLocalTask(repo);
         task.executeTask();

--- a/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
+++ b/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
@@ -63,6 +63,18 @@ public class RepoDbManager {
         }
     }
 
+    public static void persistCredentials(long repoId,String username, String password) {
+        ContentValues values = new ContentValues();
+        if (username != null && password != null) {
+            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
+            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
+        } else {
+            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
+            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
+        }
+        updateRepo(repoId, values);
+    }
+
     public static interface RepoDbObserver {
         public void nofityChanged();
     }

--- a/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
+++ b/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
@@ -117,6 +117,15 @@ public class RepoDbManager {
         return cursor;
     }
 
+    public static long createRepo(String localPath, String remoteURL) {
+        ContentValues values = new ContentValues();
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, remoteURL);
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
+            RepoContract.REPO_STATUS_WAITING_CLONE);
+        return getInstance()._insertRepo(values);
+    }
+
     public static long insertRepo(ContentValues values) {
         return getInstance()._insertRepo(values);
     }

--- a/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
+++ b/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
@@ -12,7 +12,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
 /**
- * Created by sheimi on 8/7/13.
+ * Manage entries in the persisted database tracking local repo metadata.
  */
 public class RepoDbManager {
 
@@ -118,34 +118,30 @@ public class RepoDbManager {
     }
 
     public static long createRepo(String localPath, String remoteURL) {
+        return createRepo(localPath, remoteURL, RepoContract.REPO_STATUS_WAITING_CLONE);
+    }
+
+    public static long importRepo(String localPath) {
+        return createRepo(localPath, "", RepoContract.REPO_STATUS_IMPORTING);
+    }
+
+    private static long createRepo(String localPath, String remoteURL, String status) {
         ContentValues values = new ContentValues();
         values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);
         values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, remoteURL);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
-            RepoContract.REPO_STATUS_WAITING_CLONE);
-        return getInstance()._insertRepo(values);
-    }
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS, status);
 
-    public static long insertRepo(ContentValues values) {
-        return getInstance()._insertRepo(values);
-    }
-
-    private long _insertRepo(ContentValues values) {
-        long id = mWritableDatabase.insert(RepoContract.RepoEntry.TABLE_NAME,
-                null, values);
+        long id = getInstance().mWritableDatabase.insert(RepoContract.RepoEntry.TABLE_NAME,
+            null, values);
         notifyObservers(RepoContract.RepoEntry.TABLE_NAME);
         return id;
     }
 
     public static void updateRepo(long id, ContentValues values) {
-        getInstance()._updateRepo(id, values);
-    }
-
-    private void _updateRepo(long id, ContentValues values) {
         String selection = RepoContract.RepoEntry._ID + " = ?";
         String[] selectionArgs = { String.valueOf(id) };
-        mWritableDatabase.update(RepoContract.RepoEntry.TABLE_NAME, values,
-                selection, selectionArgs);
+        getInstance().mWritableDatabase.update(RepoContract.RepoEntry.TABLE_NAME, values,
+            selection, selectionArgs);
         notifyObservers(RepoContract.RepoEntry.TABLE_NAME);
     }
 

--- a/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -601,4 +601,8 @@ public class Repo implements Comparable<Repo>, Serializable {
         } catch (StopTaskException e) {
         }
     }
+
+    public void saveCredentials() {
+        RepoDbManager.persistCredentials(getID(), getUsername(), getPassword());
+    }
 }

--- a/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -1,30 +1,14 @@
 package me.sheimi.sgit.database.models;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.sql.Time;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
-import me.sheimi.sgit.SGitApplication;
-import me.sheimi.android.utils.BasicFunctions;
-import me.sheimi.android.utils.FsUtils;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
-import me.sheimi.sgit.exception.StopTaskException;
-import me.sheimi.sgit.repo.tasks.repo.RepoOpTask;
-import timber.log.Timber;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.os.Bundle;
+import android.util.SparseArray;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -34,15 +18,26 @@ import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 
-import android.content.ContentValues;
-import android.content.Context;
-import android.database.Cursor;
-import android.os.Bundle;
-import android.util.Log;
-import android.util.SparseArray;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import me.sheimi.android.utils.FsUtils;
+import me.sheimi.sgit.SGitApplication;
+import me.sheimi.sgit.database.RepoContract;
+import me.sheimi.sgit.database.RepoDbManager;
+import me.sheimi.sgit.exception.StopTaskException;
+import me.sheimi.sgit.repo.tasks.repo.RepoOpTask;
+import timber.log.Timber;
 
 /**
- * Created by sheimi on 8/20/13.
+ * Model for a local repo
  */
 public class Repo implements Comparable<Repo>, Serializable {
 
@@ -508,10 +503,10 @@ public class Repo implements Comparable<Repo>, Serializable {
         File repoDir = FsUtils.getRepoDir(context, localpath);
         if (repoDir == null) {
             repoDir = FsUtils.getExternalDir(REPO_DIR, true);
-            Log.d("maks", "PRESET repo path:"+new File(repoDir, localpath).getAbsolutePath());
+            Timber.d("maks", "PRESET repo path:"+new File(repoDir, localpath).getAbsolutePath());
             return new File(repoDir, localpath);
         } else {
-            Log.d("maks", "CUSTOM repo path:"+repoDir);
+            Timber.d("maks", "CUSTOM repo path:"+repoDir);
             return repoDir;
         }
     }

--- a/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -101,7 +101,11 @@ public class Repo implements Comparable<Repo>, Serializable {
         return bundle;
     }
 
-    public static Repo getRepoById(Context context, long id) {
+    public static Repo createRepo(String localPath, String remoteURL) {
+        return getRepoById(RepoDbManager.createRepo(localPath, remoteURL));
+    }
+
+    public static Repo getRepoById(long id) {
         Cursor c = RepoDbManager.getRepoById(id);
         c.moveToFirst();
         Repo repo = new Repo(c);

--- a/src/main/java/me/sheimi/sgit/database/models/Repo.java
+++ b/src/main/java/me/sheimi/sgit/database/models/Repo.java
@@ -105,6 +105,10 @@ public class Repo implements Comparable<Repo>, Serializable {
         return getRepoById(RepoDbManager.createRepo(localPath, remoteURL));
     }
 
+    public static Repo importRepo(String localPath) {
+        return getRepoById(RepoDbManager.importRepo(localPath));
+    }
+
     public static Repo getRepoById(long id) {
         Cursor c = RepoDbManager.getRepoById(id);
         c.moveToFirst();
@@ -597,5 +601,4 @@ public class Repo implements Comparable<Repo>, Serializable {
         } catch (StopTaskException e) {
         }
     }
-
 }

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -167,13 +167,8 @@ public class CloneDialog extends SheimiDialogFragment implements
     public void onClicked(String username, String password, boolean savePassword) {
         String remoteURL = mBinding.remoteURL.getText().toString().trim();
         String localPath = mBinding.localPath.getText().toString().trim();
-        ContentValues values = new ContentValues();
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, remoteURL);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
-                RepoContract.REPO_STATUS_WAITING_CLONE);
-        long id = RepoDbManager.insertRepo(values);
-        mRepo = Repo.getRepoById(mActivity, id);
+
+        mRepo = Repo.createRepo(localPath, remoteURL);
 
         mRepo.setUsername(username);
         mRepo.setPassword(password);

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -2,16 +2,12 @@ package me.sheimi.sgit.dialogs;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.ContentValues;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.EditText;
 
 import java.io.File;
 
@@ -20,8 +16,6 @@ import me.sheimi.android.utils.Profile;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.RepoListActivity;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.databinding.DialogCloneBinding;
 import me.sheimi.sgit.repo.tasks.repo.CloneTask;

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -25,6 +25,7 @@ import me.sheimi.sgit.database.RepoDbManager;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.databinding.DialogCloneBinding;
 import me.sheimi.sgit.repo.tasks.repo.CloneTask;
+import timber.log.Timber;
 
 /**
  * Dialog UI used to perform clone operation
@@ -104,13 +105,6 @@ public class CloneDialog extends SheimiDialogFragment implements
     private void fillInformationFromPreviousCloneFail(Repo lastCloneTryRepo) {
         mBinding.remoteURL.setText( lastCloneTryRepo.getRemoteURL() );
         mBinding.localPath.setText( lastCloneTryRepo.getLocalPath() );
-        mBinding.username.setText( lastCloneTryRepo.getUsername() );
-        mBinding.password.setText( lastCloneTryRepo.getPassword() );
-        if ( lastCloneTryRepo.getUsername().equals("") && lastCloneTryRepo.getPassword().equals("")) {
-            mBinding.savePassword.setChecked(false);
-        } else {
-            mBinding.savePassword.setChecked(true);
-        }
     }
 
     @Override
@@ -161,10 +155,7 @@ public class CloneDialog extends SheimiDialogFragment implements
             return;
         }
 
-        String username = mBinding.username.getText().toString();
-        String password = mBinding.password.getText().toString();
-        boolean savePassword = mBinding.savePassword.isChecked();
-        onClicked(username, password, savePassword);
+        onClicked(null, null, false);
         dismiss();
     }
 
@@ -181,19 +172,13 @@ public class CloneDialog extends SheimiDialogFragment implements
         values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, remoteURL);
         values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
                 RepoContract.REPO_STATUS_WAITING_CLONE);
-        if (savePassword) {
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
-        } else {
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
-        }
         long id = RepoDbManager.insertRepo(values);
         mRepo = Repo.getRepoById(mActivity, id);
 
         mRepo.setUsername(username);
         mRepo.setPassword(password);
 
+        Timber.d("clone with u:%s p:%s", username, password);
         CloneTask task = new CloneTask(mRepo, this, mBinding.cloneRecursive.isChecked());
         task.executeTask();
     }

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -11,7 +11,6 @@ import android.widget.Button;
 
 import java.io.File;
 
-import me.sheimi.android.activities.SheimiFragmentActivity.OnPasswordEntered;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
@@ -19,14 +18,12 @@ import me.sheimi.sgit.RepoListActivity;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.databinding.DialogCloneBinding;
 import me.sheimi.sgit.repo.tasks.repo.CloneTask;
-import timber.log.Timber;
 
 /**
  * Dialog UI used to perform clone operation
  */
 
-public class CloneDialog extends SheimiDialogFragment implements
-        View.OnClickListener, OnPasswordEntered {
+public class CloneDialog extends SheimiDialogFragment implements View.OnClickListener {
 
     private RepoListActivity mActivity;
     private Repo mRepo;
@@ -149,34 +146,17 @@ public class CloneDialog extends SheimiDialogFragment implements
             return;
         }
 
-        onClicked(null, null, false);
+        cloneRepo();
         dismiss();
     }
 
     public void cloneRepo() {
-        onClicked(null, null, false);
-    }
-
-    @Override
-    public void onClicked(String username, String password, boolean savePassword) {
         String remoteURL = mBinding.remoteURL.getText().toString().trim();
         String localPath = mBinding.localPath.getText().toString().trim();
 
         mRepo = Repo.createRepo(localPath, remoteURL);
 
-        mRepo.setUsername(username);
-        mRepo.setPassword(password);
-        if (savePassword) {
-            mRepo.saveCredentials();
-        }
-
-        Timber.d("clone with u:%s p:%s", username, password);
-        CloneTask task = new CloneTask(mRepo, this, mBinding.cloneRecursive.isChecked());
+        CloneTask task = new CloneTask(mRepo, mBinding.cloneRecursive.isChecked(), null);
         task.executeTask();
-    }
-
-    @Override
-    public void onCanceled() {
-        mRepo.deleteRepo();
     }
 }

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -166,6 +166,9 @@ public class CloneDialog extends SheimiDialogFragment implements
 
         mRepo.setUsername(username);
         mRepo.setPassword(password);
+        if (savePassword) {
+            mRepo.saveCredentials();
+        }
 
         Timber.d("clone with u:%s p:%s", username, password);
         CloneTask task = new CloneTask(mRepo, this, mBinding.cloneRecursive.isChecked());

--- a/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
@@ -146,7 +146,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
     }
 
     private void updateRepoInformation(long repoId) {
-        Repo repo = Repo.getRepoById(mActivity, repoId);
+        Repo repo = Repo.getRepoById(repoId);
         repo.updateLatestCommitInfo();
         repo.updateRemote();
         repo.updateStatus(RepoContract.REPO_STATUS_NULL);

--- a/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
@@ -1,17 +1,8 @@
 package me.sheimi.sgit.dialogs;
 
-import java.io.File;
-
-import me.sheimi.android.utils.FsUtils;
-import me.sheimi.android.views.SheimiDialogFragment;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
-import me.sheimi.sgit.database.models.Repo;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.ContentValues;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -19,6 +10,14 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
+
+import java.io.File;
+
+import me.sheimi.android.utils.FsUtils;
+import me.sheimi.android.views.SheimiDialogFragment;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.RepoContract;
+import me.sheimi.sgit.database.models.Repo;
 
 /**
  * Created by sheimi on 8/24/13.
@@ -114,17 +113,10 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
             }
         }
 
-        ContentValues values = new ContentValues();
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, "");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
-                RepoContract.REPO_STATUS_IMPORTING);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
+        final Repo repo = Repo.importRepo(localPath);
 
-        final long id = RepoDbManager.insertRepo(values);
         if (mImportAsExternal.isChecked()) {
-            updateRepoInformation(id);
+            updateRepoInformation(repo);
             dismiss();
             return;
         }
@@ -136,7 +128,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
                 mActivity.runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        updateRepoInformation(id);
+                        updateRepoInformation(repo);
                     }
                 });
             }
@@ -145,8 +137,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
         dismiss();
     }
 
-    private void updateRepoInformation(long repoId) {
-        Repo repo = Repo.getRepoById(repoId);
+    private void updateRepoInformation(Repo repo) {
         repo.updateLatestCommitInfo();
         repo.updateRemote();
         repo.updateStatus(RepoContract.REPO_STATUS_NULL);

--- a/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
@@ -1,22 +1,20 @@
 package me.sheimi.sgit.dialogs;
 
-import java.io.File;
-
-import me.sheimi.android.views.SheimiDialogFragment;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.RepoListActivity;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
-import me.sheimi.sgit.database.models.Repo;
-import me.sheimi.sgit.repo.tasks.repo.InitLocalTask;
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.content.ContentValues;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+
+import java.io.File;
+
+import me.sheimi.android.views.SheimiDialogFragment;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.RepoListActivity;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.repo.tasks.repo.InitLocalTask;
 
 /**
  * Created by sheimi on 8/24/13.
@@ -89,15 +87,7 @@ public class InitDialog extends SheimiDialogFragment implements
         }
 
         localPath = mLocalPath.getText().toString().trim();
-        ContentValues values = new ContentValues();
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REMOTE_URL, "local repository");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_REPO_STATUS,
-                RepoContract.REPO_STATUS_INITING);
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
-        values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
-        long id = RepoDbManager.insertRepo(values);
-        mRepo = Repo.getRepoById(id);
+        mRepo = Repo.createRepo(localPath, "local repository");
 
         InitLocalTask task = new InitLocalTask(mRepo);
         task.executeTask();

--- a/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
@@ -97,7 +97,7 @@ public class InitDialog extends SheimiDialogFragment implements
         values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, "");
         values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, "");
         long id = RepoDbManager.insertRepo(values);
-        mRepo = Repo.getRepoById(mActivity, id);
+        mRepo = Repo.getRepoById(id);
 
         InitLocalTask task = new InitLocalTask(mRepo);
         task.executeTask();

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/CloneTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/CloneTask.java
@@ -9,6 +9,7 @@ import me.sheimi.sgit.R;
 import me.sheimi.sgit.database.RepoContract;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.ssh.SgitTransportCallback;
+import timber.log.Timber;
 
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
@@ -60,15 +61,8 @@ public class CloneTask extends RepoOpTask {
                 .setDirectory(localRepo)
                 .setCloneSubmodules(mCloneRecursive);
 
-        String username = mRepo.getUsername();
-        String password = mRepo.getPassword();
+        setCredentials(cloneCommand);
 
-        if (username != null && password != null && !username.equals("")
-                && !password.equals("")) {
-            UsernamePasswordCredentialsProvider auth = new UsernamePasswordCredentialsProvider(
-                    username, password);
-            cloneCommand.setCredentialsProvider(auth);
-        }
         try {
             cloneCommand.call();
             Profile.setLastCloneSuccess();

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/CloneTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/CloneTask.java
@@ -1,5 +1,13 @@
 package me.sheimi.sgit.repo.tasks.repo;
 
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.lib.ProgressMonitor;
+
 import java.io.File;
 import java.util.Locale;
 
@@ -11,34 +19,27 @@ import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.ssh.SgitTransportCallback;
 import timber.log.Timber;
 
-import org.eclipse.jgit.api.CloneCommand;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.InvalidRemoteException;
-import org.eclipse.jgit.api.errors.JGitInternalException;
-import org.eclipse.jgit.api.errors.TransportException;
-import org.eclipse.jgit.lib.ProgressMonitor;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+public class CloneTask extends RepoRemoteOpTask {
 
-public class CloneTask extends RepoOpTask {
-
-    private OnPasswordEntered mOnPasswordEnter;
+    private AsyncTaskCallback mCallback;
     private boolean mCloneRecursive;
 
-    public CloneTask(Repo repo, OnPasswordEntered onPasswordEnter, boolean cloneRecursive) {
+    public CloneTask(Repo repo, boolean cloneRecursive, AsyncTaskCallback callback) {
         super(repo);
         mCloneRecursive = cloneRecursive;
-        mOnPasswordEnter = onPasswordEnter;
+        mCallback = callback;
     }
 
     @Override
     protected Boolean doInBackground(Void... v) {
         boolean result = cloneRepo();
         if (!result) {
+            Timber.e("del repo. clone failed");
             mRepo.deleteRepoSync();
-            return false;
+        } else if (mCallback != null) {
+            result = mCallback.doInBackground(v) & result;
         }
-        return true;
+        return result;
     }
 
     protected void onPostExecute(Boolean isSuccess) {
@@ -73,7 +74,7 @@ public class CloneTask extends RepoOpTask {
         } catch (TransportException e) {
             setException(e);
             Profile.setLastCloneFailed(mRepo);
-            handleAuthError(mOnPasswordEnter);
+            handleAuthError(this);
             return false;
         } catch (GitAPIException e) {
             setException(e, R.string.error_clone_failed);
@@ -95,6 +96,17 @@ public class CloneTask extends RepoOpTask {
     public void cancelTask() {
         super.cancelTask();
         mRepo.deleteRepo();
+    }
+
+    @Override
+    public RepoRemoteOpTask getNewTask() {
+        // need to call create repo again as when clone fails due auth error, the repo initially created gets deleted
+        String userName = mRepo.getUsername();
+        String password = mRepo.getPassword();
+        mRepo = Repo.createRepo(mRepo.getLocalPath(), mRepo.getRemoteURL());
+        mRepo.setUsername(userName);
+        mRepo.setPassword(password);
+        return new CloneTask(mRepo, mCloneRecursive, mCallback);
     }
 
     public class RepoCloneMonitor implements ProgressMonitor {

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
@@ -59,6 +59,7 @@ public class FetchTask extends RepoOpTask implements SheimiFragmentActivity.OnPa
 
     @Override
     public void onClicked(String username, String password, boolean savePassword) {
+
     }
 
     @Override
@@ -78,14 +79,7 @@ public class FetchTask extends RepoOpTask implements SheimiFragmentActivity.OnPa
                 .setTransportConfigCallback(new SgitTransportCallback())
                 .setRemote(remote);
 
-        final String username = mRepo.getUsername();
-        final String password = mRepo.getPassword();
-        if (username != null && password != null && !username.equals("")
-                && !password.equals("")) {
-            UsernamePasswordCredentialsProvider auth = new UsernamePasswordCredentialsProvider(
-                    username, password);
-            fetchCommand.setCredentialsProvider(auth);
-        }
+        setCredentials(fetchCommand);
 
         try {
             fetchCommand.call();

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
@@ -91,4 +91,13 @@ public class FetchTask extends RepoRemoteOpTask {
         mRepo.updateLatestCommitInfo();
         return true;
     }
+
+    @Override
+    public void onClicked(String username, String password, boolean savePassword) {
+        super.onClicked(username, password, savePassword);
+
+        mRepo.removeTask(this);
+        FetchTask fetchTask = new FetchTask(mRemotes, mRepo, mCallback);
+        fetchTask.executeTask();
+    }
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
@@ -11,7 +11,7 @@ import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.exception.StopTaskException;
 import me.sheimi.sgit.ssh.SgitTransportCallback;
 
-public class FetchTask extends RepoOpTask implements SheimiFragmentActivity.OnPasswordEntered {
+public class FetchTask extends RepoRemoteOpTask {
 
     private final AsyncTaskCallback mCallback;
     private final String[] mRemotes;
@@ -55,15 +55,6 @@ public class FetchTask extends RepoOpTask implements SheimiFragmentActivity.OnPa
         if (mCallback != null) {
             mCallback.onPostExecute(isSuccess);
         }
-    }
-
-    @Override
-    public void onClicked(String username, String password, boolean savePassword) {
-
-    }
-
-    @Override
-    public void onCanceled() {
     }
 
     private boolean fetchRepo(String remote) {

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/FetchTask.java
@@ -93,11 +93,7 @@ public class FetchTask extends RepoRemoteOpTask {
     }
 
     @Override
-    public void onClicked(String username, String password, boolean savePassword) {
-        super.onClicked(username, password, savePassword);
-
-        mRepo.removeTask(this);
-        FetchTask fetchTask = new FetchTask(mRemotes, mRepo, mCallback);
-        fetchTask.executeTask();
+    public RepoRemoteOpTask getNewTask() {
+        return new FetchTask(mRemotes, mRepo, mCallback);
     }
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
@@ -74,14 +74,9 @@ public class PullTask extends RepoOpTask implements OnPasswordEntered {
                 .setRemote(mRemote)
                 .setProgressMonitor(new BasicProgressMonitor())
                 .setTransportConfigCallback(new SgitTransportCallback());
-        String username = mRepo.getUsername();
-        String password = mRepo.getPassword();
-        if (username != null && password != null && !username.equals("")
-                && !password.equals("")) {
-            UsernamePasswordCredentialsProvider auth = new UsernamePasswordCredentialsProvider(
-                    username, password);
-            pullCommand.setCredentialsProvider(auth);
-        }
+
+        setCredentials(pullCommand);
+
         try {
             String branch = null;
             if (mForcePull) {

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
@@ -123,12 +123,8 @@ public class PullTask extends RepoRemoteOpTask {
     }
 
     @Override
-    public void onClicked(String username, String password, boolean savePassword) {
-        super.onClicked(username, password, savePassword);
-
-        mRepo.removeTask(this);
-        PullTask pullTask = new PullTask(mRepo, mRemote, mForcePull, mCallback);
-        pullTask.executeTask();
+    public RepoRemoteOpTask getNewTask() {
+        return new PullTask(mRepo, mRemote, mForcePull, mCallback);
     }
 
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PullTask.java
@@ -1,24 +1,18 @@
 package me.sheimi.sgit.repo.tasks.repo;
 
-import me.sheimi.android.activities.SheimiFragmentActivity.OnPasswordEntered;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
-import me.sheimi.sgit.database.models.Repo;
-import me.sheimi.sgit.exception.StopTaskException;
-import me.sheimi.sgit.ssh.SgitTransportCallback;
-
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PullCommand;
 import org.eclipse.jgit.api.RebaseCommand;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
-import android.content.ContentValues;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.exception.StopTaskException;
+import me.sheimi.sgit.ssh.SgitTransportCallback;
 
-public class PullTask extends RepoOpTask implements OnPasswordEntered {
+public class PullTask extends RepoRemoteOpTask {
 
     private AsyncTaskCallback mCallback;
     private String mRemote;
@@ -130,21 +124,11 @@ public class PullTask extends RepoOpTask implements OnPasswordEntered {
 
     @Override
     public void onClicked(String username, String password, boolean savePassword) {
-        mRepo.setUsername(username);
-        mRepo.setPassword(password);
-        if (savePassword) {
-            ContentValues values = new ContentValues();
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
-            RepoDbManager.updateRepo(mRepo.getID(), values);
-        }
+        super.onClicked(username, password, savePassword);
 
         mRepo.removeTask(this);
         PullTask pullTask = new PullTask(mRepo, mRemote, mForcePull, mCallback);
         pullTask.executeTask();
     }
 
-    @Override
-    public void onCanceled() {
-    }
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
@@ -1,27 +1,21 @@
 package me.sheimi.sgit.repo.tasks.repo;
 
-import java.util.Collection;
-
-import me.sheimi.android.activities.SheimiFragmentActivity.OnPasswordEntered;
-import me.sheimi.android.utils.BasicFunctions;
-import me.sheimi.sgit.R;
-import me.sheimi.sgit.database.RepoContract;
-import me.sheimi.sgit.database.RepoDbManager;
-import me.sheimi.sgit.database.models.Repo;
-import me.sheimi.sgit.exception.StopTaskException;
-import me.sheimi.sgit.ssh.SgitTransportCallback;
-
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
-import android.content.ContentValues;
+import java.util.Collection;
 
-public class PushTask extends RepoOpTask implements OnPasswordEntered {
+import me.sheimi.android.utils.BasicFunctions;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.exception.StopTaskException;
+import me.sheimi.sgit.ssh.SgitTransportCallback;
+
+public class PushTask extends RepoRemoteOpTask {
 
     private AsyncTaskCallback mCallback;
     private boolean mPushAll;
@@ -183,14 +177,7 @@ public class PushTask extends RepoOpTask implements OnPasswordEntered {
 
     @Override
     public void onClicked(String username, String password, boolean savePassword) {
-        mRepo.setUsername(username);
-        mRepo.setPassword(password);
-        if (savePassword) {
-            ContentValues values = new ContentValues();
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_USERNAME, username);
-            values.put(RepoContract.RepoEntry.COLUMN_NAME_PASSWORD, password);
-            RepoDbManager.updateRepo(mRepo.getID(), values);
-        }
+        super.onClicked(username, password, savePassword);
 
         mRepo.removeTask(this);
         PushTask pushTask = new PushTask(mRepo, mRemote, mPushAll, mForcePush, mCallback);

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
@@ -176,16 +176,8 @@ public class PushTask extends RepoRemoteOpTask {
     }
 
     @Override
-    public void onClicked(String username, String password, boolean savePassword) {
-        super.onClicked(username, password, savePassword);
-
-        mRepo.removeTask(this);
-        PushTask pushTask = new PushTask(mRepo, mRemote, mPushAll, mForcePush, mCallback);
-        pushTask.executeTask();
-    }
-
-    @Override
-    public void onCanceled() {
+    public RepoRemoteOpTask getNewTask() {
+        return new PushTask(mRepo, mRemote, mPushAll, mForcePush, mCallback);
     }
 
 }

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/PushTask.java
@@ -96,14 +96,7 @@ public class PushTask extends RepoOpTask implements OnPasswordEntered {
           pushCommand.setForce(true);
         }
 
-        String username = mRepo.getUsername();
-        String password = mRepo.getPassword();
-        if (username != null && password != null && !username.equals("")
-                && !password.equals("")) {
-            UsernamePasswordCredentialsProvider auth = new UsernamePasswordCredentialsProvider(
-                    username, password);
-            pushCommand.setCredentialsProvider(auth);
-        }
+        setCredentials(pushCommand);
 
         try {
             Iterable<PushResult> result = pushCommand.call();

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoRemoteOpTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoRemoteOpTask.java
@@ -1,0 +1,31 @@
+package me.sheimi.sgit.repo.tasks.repo;
+
+import me.sheimi.android.activities.SheimiFragmentActivity;
+import me.sheimi.sgit.database.models.Repo;
+
+/**
+ * Super class for Tasks that operate on a git remote
+ */
+
+public abstract class RepoRemoteOpTask extends RepoOpTask implements SheimiFragmentActivity.OnPasswordEntered {
+
+
+    public RepoRemoteOpTask(Repo repo) {
+        super(repo);
+    }
+
+
+    @Override
+    public void onClicked(String username, String password, boolean savePassword) {
+        mRepo.setUsername(username);
+        mRepo.setPassword(password);
+        if (savePassword) {
+            mRepo.saveCredentials();
+        }
+    }
+
+    @Override
+    public void onCanceled() {
+
+    }
+}

--- a/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoRemoteOpTask.java
+++ b/src/main/java/me/sheimi/sgit/repo/tasks/repo/RepoRemoteOpTask.java
@@ -22,10 +22,15 @@ public abstract class RepoRemoteOpTask extends RepoOpTask implements SheimiFragm
         if (savePassword) {
             mRepo.saveCredentials();
         }
+
+        mRepo.removeTask(this);
+        getNewTask().executeTask();
     }
 
     @Override
     public void onCanceled() {
 
     }
+
+    public abstract RepoRemoteOpTask getNewTask();
 }

--- a/src/main/res/layout/dialog_clone.xml
+++ b/src/main/res/layout/dialog_clone.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+<LinearLayout
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
@@ -64,3 +66,4 @@
             android:layout_gravity="left|center_vertical"
             android:checked="false"/>
 </LinearLayout>
+</layout>

--- a/src/main/res/layout/dialog_clone.xml
+++ b/src/main/res/layout/dialog_clone.xml
@@ -29,35 +29,6 @@
             android:imeOptions="actionNext"
             android:hint="@string/dialog_clone_local_path_hint"/>
 
-    <EditText
-            android:id="@+id/username"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/general_dialog_text_size"
-            android:layout_margin="@dimen/general_vertial_margin"
-            android:singleLine="true"
-            android:imeOptions="actionNext"
-            android:hint="@string/label_username"/>
-
-    <EditText
-            android:id="@+id/password"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/general_dialog_text_size"
-            android:layout_margin="@dimen/general_vertial_margin"
-            android:singleLine="true"
-            android:inputType="textPassword"
-            android:imeOptions="actionDone"
-            android:hint="@string/label_password"/>
-
-    <CheckBox
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/dialog_prompt_for_password_checkbox"
-            android:id="@+id/savePassword"
-            android:layout_gravity="left|center_vertical"
-            android:checked="true"/>
-
     <CheckBox
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
This removes credentials fields (username/password) from the clone dialog as the user will be prompted for this if required because the clone will fail with an auth error and there is already functionality to handle this (eg. if incorrect credentials are entered by the user accidentally).
This also cleans up code that was directly accessing the sqlite persistence layer directly from the view layer (bypassing the model) and refactors all the "op task" classes that operate on a remote repo and makes clone task consistent with the others (pull, push, fetch).