### PR TITLE
Make existing repos 'external' when changing root

### DIFF
--- a/src/main/java/me/sheimi/android/utils/FsUtils.java
+++ b/src/main/java/me/sheimi/android/utils/FsUtils.java
@@ -98,25 +98,6 @@ public class FsUtils {
         }
     }
 
-    /**
-     * Returns the root directory on device storage in which local repos ar to be stored
-     *
-     * @param context
-     * @param name
-     * @return null if the custom repo location user preference is *not* set
-     */
-    public static File getRepoDir(Context context, String repoName) {
-        SharedPreferences sharedPreference = context.getSharedPreferences(
-                context.getString(R.string.preference_file_key), Context.MODE_PRIVATE);
-
-        String repoRootDir = sharedPreference.getString(context.getString(R.string.pref_key_repo_root_location), "");
-        if (repoRootDir != null && !repoRootDir.isEmpty()) {
-           return new File(repoRootDir, repoName);
-        } else {
-            return null;
-        }
-    }
-
     public static String getMimeType(String url) {
         String type = null;
         String extension = MimeTypeMap.getFileExtensionFromUrl(url

--- a/src/main/java/me/sheimi/sgit/SGitApplication.java
+++ b/src/main/java/me/sheimi/sgit/SGitApplication.java
@@ -11,6 +11,7 @@ import org.eclipse.jgit.transport.CredentialsProvider;
 
 import me.sheimi.android.utils.SecurePrefsException;
 import me.sheimi.android.utils.SecurePrefsHelper;
+import me.sheimi.sgit.preference.PreferenceHelper;
 import timber.log.Timber;
 
 /**
@@ -27,6 +28,7 @@ public class SGitApplication extends Application {
     private static CredentialsProvider mCredentialsProvider;
 
     private SecurePrefsHelper mSecPrefs;
+    private PreferenceHelper mPrefsHelper;
 
     @Override
     public void onCreate() {
@@ -38,6 +40,7 @@ public class SGitApplication extends Application {
 
         mContext = getApplicationContext();
         setAppVersionPref();
+        mPrefsHelper = new PreferenceHelper(this);
         try {
             mSecPrefs = new SecurePrefsHelper(this);
             mCredentialsProvider = new AndroidJschCredentialsProvider(mSecPrefs);
@@ -58,6 +61,10 @@ public class SGitApplication extends Application {
 
     public SecurePrefsHelper getSecurePrefsHelper() {
         return mSecPrefs;
+    }
+
+    public PreferenceHelper getPrefenceHelper() {
+        return mPrefsHelper;
     }
 
     public static Context getContext() {

--- a/src/main/java/me/sheimi/sgit/activities/explorer/ExploreRootDirActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/explorer/ExploreRootDirActivity.java
@@ -1,9 +1,6 @@
 package me.sheimi.sgit.activities.explorer;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Environment;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -13,10 +10,13 @@ import java.io.File;
 import java.io.FileFilter;
 
 import me.sheimi.sgit.R;
+import me.sheimi.sgit.SGitApplication;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.preference.PreferenceHelper;
 
 public class ExploreRootDirActivity extends FileExplorerActivity {
 
-    private static final String LOGTAG = ExploreRootDirActivity.class.getSimpleName();
+
 
     @Override
     protected File getRootFolder() {
@@ -65,14 +65,7 @@ public class ExploreRootDirActivity extends FileExplorerActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_select_root:
-                SharedPreferences sharedPreference = getSharedPreferences(
-                        getString(R.string.preference_file_key), Context.MODE_PRIVATE);
-
-                SharedPreferences.Editor editor = sharedPreference.edit();
-                editor.putString(getString(R.string.pref_key_repo_root_location),
-                        getCurrentDir().getAbsolutePath());
-                Log.d(LOGTAG, "set root:"+getCurrentDir().getAbsolutePath());
-                editor.commit();
+                Repo.setLocalRepoRoot(this, getCurrentDir());
                 finish();
                 return true;
         }

--- a/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
+++ b/src/main/java/me/sheimi/sgit/database/RepoDbManager.java
@@ -137,6 +137,12 @@ public class RepoDbManager {
         return createRepo(localPath, "", RepoContract.REPO_STATUS_IMPORTING);
     }
 
+    public static void setLocalPath(long repoId, String path) {
+        ContentValues values = new ContentValues();
+        values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, path);
+        updateRepo(repoId, values);
+    }
+
     private static long createRepo(String localPath, String remoteURL, String status) {
         ContentValues values = new ContentValues();
         values.put(RepoContract.RepoEntry.COLUMN_NAME_LOCAL_PATH, localPath);

--- a/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/CloneDialog.java
@@ -15,8 +15,10 @@ import me.sheimi.android.utils.Profile;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.RepoListActivity;
+import me.sheimi.sgit.SGitApplication;
 import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.databinding.DialogCloneBinding;
+import me.sheimi.sgit.preference.PreferenceHelper;
 import me.sheimi.sgit.repo.tasks.repo.CloneTask;
 
 /**
@@ -28,6 +30,7 @@ public class CloneDialog extends SheimiDialogFragment implements View.OnClickLis
     private RepoListActivity mActivity;
     private Repo mRepo;
     private DialogCloneBinding mBinding;
+    private PreferenceHelper mPrefsHelper;
 
     private class RemoteUrlFocusListener implements View.OnFocusChangeListener {
         @Override
@@ -64,6 +67,9 @@ public class CloneDialog extends SheimiDialogFragment implements View.OnClickLis
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
         mActivity = (RepoListActivity) getActivity();
+
+        mPrefsHelper = ((SGitApplication)mActivity.getApplicationContext()).getPrefenceHelper();
+
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
         LayoutInflater inflater = mActivity.getLayoutInflater();
 
@@ -138,7 +144,7 @@ public class CloneDialog extends SheimiDialogFragment implements View.OnClickLis
         if (mBinding.localPath.getHint().toString() != getString(R.string.dialog_clone_local_path_hint)) {
             localPath = mBinding.localPath.getHint().toString();
         }
-        File file = Repo.getDir(getActivity(), localPath);
+        File file = Repo.getDir(mPrefsHelper, localPath);
         if (file.exists()) {
             showToastMessage(R.string.alert_localpath_repo_exists);
             mBinding.localPath.setError(getString(R.string.alert_localpath_repo_exists));

--- a/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/ImportLocalRepoDialog.java
@@ -16,8 +16,10 @@ import java.io.File;
 import me.sheimi.android.utils.FsUtils;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
+import me.sheimi.sgit.SGitApplication;
 import me.sheimi.sgit.database.RepoContract;
 import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.preference.PreferenceHelper;
 
 /**
  * Created by sheimi on 8/24/13.
@@ -31,6 +33,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
     private Activity mActivity;
     private EditText mLocalPath;
     private CheckBox mImportAsExternal;
+    private PreferenceHelper mPrefsHelper;
     public static final String FROM_PATH = "from path";
 
     @Override
@@ -38,6 +41,9 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
         super.onCreateDialog(savedInstanceState);
 
         mActivity = getActivity();
+
+        mPrefsHelper = ((SGitApplication)mActivity.getApplicationContext()).getPrefenceHelper();
+
         Bundle args = getArguments();
         if (args != null && args.containsKey(FROM_PATH)) {
             mFromPath = args.getString(FROM_PATH);
@@ -104,8 +110,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
                 return;
             }
 
-            File file = Repo.getDir(getActivity(), localPath);
-
+            File file = Repo.getDir(mPrefsHelper, localPath);
             if (file.exists()) {
                 showToastMessage(R.string.alert_file_exists);
                 mLocalPath.setError(getString(R.string.alert_file_exists));
@@ -120,7 +125,7 @@ public class ImportLocalRepoDialog extends SheimiDialogFragment implements
             dismiss();
             return;
         }
-        final File repoFile = Repo.getDir(getActivity(), localPath);
+        final File repoFile = Repo.getDir(mPrefsHelper, localPath);
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
+++ b/src/main/java/me/sheimi/sgit/dialogs/InitDialog.java
@@ -13,7 +13,9 @@ import java.io.File;
 import me.sheimi.android.views.SheimiDialogFragment;
 import me.sheimi.sgit.R;
 import me.sheimi.sgit.RepoListActivity;
+import me.sheimi.sgit.SGitApplication;
 import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.preference.PreferenceHelper;
 import me.sheimi.sgit.repo.tasks.repo.InitLocalTask;
 
 /**
@@ -26,11 +28,15 @@ public class InitDialog extends SheimiDialogFragment implements
     private EditText mLocalPath;
     private RepoListActivity mActivity;
     private Repo mRepo;
+    private PreferenceHelper mPrefsHelper;
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
         mActivity = (RepoListActivity) getActivity();
+
+        mPrefsHelper = ((SGitApplication)mActivity.getApplicationContext()).getPrefenceHelper();
+
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
         LayoutInflater inflater = mActivity.getLayoutInflater();
         View layout = inflater.inflate(R.layout.dialog_init_repo, null);
@@ -77,7 +83,7 @@ public class InitDialog extends SheimiDialogFragment implements
             return;
         }
 
-        File file = Repo.getDir(getActivity(), localPath);
+        File file = Repo.getDir(mPrefsHelper, localPath);
         if (file.exists()) {
             showToastMessage(R.string.alert_localpath_repo_exists);
             mLocalPath

--- a/src/main/java/me/sheimi/sgit/preference/PreferenceHelper.java
+++ b/src/main/java/me/sheimi/sgit/preference/PreferenceHelper.java
@@ -1,0 +1,83 @@
+package me.sheimi.sgit.preference;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.io.File;
+
+import me.sheimi.sgit.R;
+import timber.log.Timber;
+
+/**
+ * Clean, central access to getting/setting user preferences
+ */
+
+public class PreferenceHelper {
+
+    private static final int DEFAULT_INT = 0;
+    private static final boolean DEFAULT_BOOLEAN = false;
+    private static final String DEFAULT_STRING = "";
+
+    private final Context mContext;
+
+    public PreferenceHelper(Context context) {
+        mContext = context.getApplicationContext();
+    }
+
+    /**
+     * Returns the root directory on device storage in which new local repos will be stored
+     *
+     * @return null if the custom repo location user preference is *not* set
+     */
+    public File getRepoRoot() {
+        String repoRootDir = getString(mContext.getString(R.string.pref_key_repo_root_location));
+        if (repoRootDir != null && !repoRootDir.isEmpty()) {
+            return new File(repoRootDir);
+        } else {
+            return null;
+        }
+    }
+
+    public void setRepoRoot(String repoRootPath) {
+        edit(mContext.getString(R.string.pref_key_repo_root_location), repoRootPath);
+        Timber.d("set root:"+repoRootPath);
+    }
+
+
+    protected SharedPreferences getSharedPrefs() {
+        return mContext.getSharedPreferences(
+            mContext.getString(R.string.preference_file_key), Context.MODE_PRIVATE);
+    }
+
+
+    private void edit(String name, String value) {
+        SharedPreferences.Editor editor = getSharedPrefs().edit();
+        editor.putString(name, value);
+        editor.apply();
+    }
+
+    private void edit(String name, int value) {
+        SharedPreferences.Editor editor =  getSharedPrefs().edit();
+        editor.putInt(name, value);
+        editor.apply();
+    }
+
+    private void edit(String name, boolean value) {
+        SharedPreferences.Editor editor =  getSharedPrefs().edit();
+        editor.putBoolean(name, value);
+        editor.apply();
+    }
+
+    private String getString(String name) {
+        return getSharedPrefs().getString(name, DEFAULT_STRING);
+    }
+
+    private int getInt(String name) {
+        return  getSharedPrefs().getInt(name, DEFAULT_INT);
+    }
+
+    private boolean getBoolean(String name) {
+        return  getSharedPrefs().getBoolean(name, DEFAULT_BOOLEAN);
+    }
+}


### PR DESCRIPTION
When the root dir for local repos changes, we need to mark any existing "internal" repos "external" so as to preserve the correct path to them as currently MGit only stores the relative dir name to the root when
storing paths in the sqlite db