### PR TITLE
suppress lint warning for commit over apply

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,7 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <issue id="CommitPrefEdits">
-        <ignore path="src/main/java/me/sheimi/sgit/SGitApplication.java" />
-        <ignore path="src/main/java/me/sheimi/android/utils/SecurePrefsHelper" />
-    </issue>
 </lint>

--- a/lint.xml
+++ b/lint.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <issue id="CommitPrefEdits">
+        <ignore path="src/main/java/me/sheimi/sgit/SGitApplication.java" />
+        <ignore path="src/main/java/me/sheimi/android/utils/SecurePrefsHelper" />
+    </issue>
 </lint>

--- a/src/main/java/me/sheimi/android/utils/SecurePrefsHelper.java
+++ b/src/main/java/me/sheimi/android/utils/SecurePrefsHelper.java
@@ -1,6 +1,5 @@
 package me.sheimi.android.utils;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -113,8 +112,7 @@ public class SecurePrefsHelper {
      * @param name
      * @param value
      */
-    @SuppressLint("ApplySharedPref")
     public void set(String name, String value) {
-        mSecurePrefs.edit().putString(name, value).commit();
+        mSecurePrefs.edit().putString(name, value).apply();
     }
 }

--- a/src/main/java/me/sheimi/android/utils/SecurePrefsHelper.java
+++ b/src/main/java/me/sheimi/android/utils/SecurePrefsHelper.java
@@ -1,11 +1,11 @@
 package me.sheimi.android.utils;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.security.KeyPairGeneratorSpec;
-import android.widget.EditText;
 
 import com.securepreferences.SecurePreferences;
 
@@ -113,6 +113,7 @@ public class SecurePrefsHelper {
      * @param name
      * @param value
      */
+    @SuppressLint("ApplySharedPref")
     public void set(String name, String value) {
         mSecurePrefs.edit().putString(name, value).commit();
     }

--- a/src/main/java/me/sheimi/sgit/SGitApplication.java
+++ b/src/main/java/me/sheimi/sgit/SGitApplication.java
@@ -1,5 +1,6 @@
 package me.sheimi.sgit;
 
+import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -67,14 +68,16 @@ public class SGitApplication extends Application {
         return mContext;
     }
 
+    @SuppressLint("ApplySharedPref")
     private void setAppVersionPref() {
         SharedPreferences sharedPreference = getSharedPreferences(
                 getString(R.string.preference_file_key),
                 Context.MODE_PRIVATE);
         String version = BuildConfig.VERSION_NAME;
-        SharedPreferences.Editor editor = sharedPreference.edit();
-        editor.putString(getString(R.string.preference_key_app_version), version);
-        editor.commit();
+        sharedPreference
+            .edit()
+            .putString(getString(R.string.preference_key_app_version), version)
+            .commit();
     }
 
     public static CredentialsProvider getJschCredentialsProvider() {

--- a/src/main/java/me/sheimi/sgit/SGitApplication.java
+++ b/src/main/java/me/sheimi/sgit/SGitApplication.java
@@ -1,6 +1,5 @@
 package me.sheimi.sgit;
 
-import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -68,7 +67,6 @@ public class SGitApplication extends Application {
         return mContext;
     }
 
-    @SuppressLint("ApplySharedPref")
     private void setAppVersionPref() {
         SharedPreferences sharedPreference = getSharedPreferences(
                 getString(R.string.preference_file_key),
@@ -77,7 +75,7 @@ public class SGitApplication extends Application {
         sharedPreference
             .edit()
             .putString(getString(R.string.preference_key_app_version), version)
-            .commit();
+            .apply();
     }
 
     public static CredentialsProvider getJschCredentialsProvider() {


### PR DESCRIPTION
I'm not sure we need to use `commit` instead of `apply` but it probably okay to use `commit`. So, we can just suppress the linting for now. 