### PR TITLE
feat (intent filters) : add supported links to clone repository

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -23,6 +23,27 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            android:label="@string/app_name">
+            <intent-filter android:label="@string/clone_with_mgit">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="*" />
+                <data android:pathPattern="@string/ending_with_git" />
+            </intent-filter>
+            <intent-filter android:label="@string/clone_with_mgit">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/https" />
+                <data android:scheme="@string/http" />
+                <data android:scheme="@string/git" />
+                <data android:scheme="@string/ssh" />
+                <data android:host="@string/github.com" />
+                <data android:host="@string/gitlab.com" />
+                <data android:host="@string/bitbucket.com" />
+                <data android:host="@string/notabug.org" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".activities.RepoDetailActivity"

--- a/src/main/java/me/sheimi/sgit/RepoListActivity.java
+++ b/src/main/java/me/sheimi/sgit/RepoListActivity.java
@@ -64,9 +64,13 @@ public class RepoListActivity extends SheimiFragmentActivity {
 
                 //need git extension to clone some repos
                 if(!remoteUrl.toLowerCase().endsWith(getString(R.string.git_extension)))
+                {
                     repoUrlBuilder.append(getString(R.string.git_extension));
+                }
                 else//if has git extension remove it from repository name
-                    repoName = repoName.substring(0, repoName.lastIndexOf('.'));
+                    {
+                        repoName = repoName.substring(0, repoName.lastIndexOf('.'));
+                    }
 
                 Repo mRepo = Repo.createRepo(repoName , repoUrlBuilder.toString() );
                 CloneTask task = new CloneTask(mRepo, true, null);

--- a/src/main/java/me/sheimi/sgit/RepoListActivity.java
+++ b/src/main/java/me/sheimi/sgit/RepoListActivity.java
@@ -4,13 +4,17 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ListView;
 import android.widget.SearchView;
+import android.widget.Toast;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import me.sheimi.android.activities.SheimiFragmentActivity;
 import me.sheimi.sgit.activities.UserSettingsActivity;
@@ -21,6 +25,7 @@ import me.sheimi.sgit.database.models.Repo;
 import me.sheimi.sgit.dialogs.CloneDialog;
 import me.sheimi.sgit.dialogs.DummyDialogListener;
 import me.sheimi.sgit.dialogs.ImportLocalRepoDialog;
+import me.sheimi.sgit.repo.tasks.repo.CloneTask;
 import me.sheimi.sgit.ssh.PrivateKeyUtils;
 
 public class RepoListActivity extends SheimiFragmentActivity {
@@ -41,6 +46,33 @@ public class RepoListActivity extends SheimiFragmentActivity {
         mRepoListAdapter.queryAllRepo();
         mRepoList.setOnItemClickListener(mRepoListAdapter);
         mRepoList.setOnItemLongClickListener(mRepoListAdapter);
+
+        Uri uri = this.getIntent().getData();
+        if(uri != null){
+            URL mRemoteRepoUrl = null;
+            try {
+                mRemoteRepoUrl = new URL(uri.getScheme(), uri.getHost(), uri.getPath());
+            } catch (MalformedURLException e) {
+                Toast.makeText(getApplicationContext(), R.string.invalid_url, Toast.LENGTH_LONG).show();
+                e.printStackTrace();
+            }
+
+            if(mRemoteRepoUrl != null){
+                String remoteUrl = mRemoteRepoUrl.toString();
+                String repoName = remoteUrl.substring(remoteUrl.lastIndexOf("/")+1);
+                StringBuilder repoUrlBuilder = new StringBuilder(remoteUrl);
+
+                //need git extension to clone some repos
+                if(!remoteUrl.toLowerCase().endsWith(getString(R.string.git_extension)))
+                    repoUrlBuilder.append(getString(R.string.git_extension));
+                else//if has git extension remove it from repository name
+                    repoName = repoName.substring(0, repoName.lastIndexOf('.'));
+
+                Repo mRepo = Repo.createRepo(repoName , repoUrlBuilder.toString() );
+                CloneTask task = new CloneTask(mRepo, true, null);
+                task.executeTask();
+            }
+        }
     }
 
     @Override

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -179,15 +179,15 @@
 
     <!-- Intent filters -->
     <string name="clone_with_mgit">Clone with MGit</string>
-    <string name="https">https</string>
-    <string name="http">http</string>
-    <string name="git">git</string>
-    <string name="git_extension">.git</string>
-    <string name="ending_with_git">.*\\.git</string>
-    <string name="ssh">ssh</string>
-    <string name="github.com">github.com</string>
-    <string name="gitlab.com">gitlab.com</string>
-    <string name="bitbucket.com">bitbucket.com</string>
-    <string name="notabug.org">notabug.org</string>
     <string name="invalid_url">Invalid URL!</string>
+    <string name="https" translatable="false">https</string>
+    <string name="http" translatable="false">http</string>
+    <string name="git" translatable="false">git</string>
+    <string name="git_extension" translatable="false">.git</string>
+    <string name="ending_with_git" translatable="false">.*\\.git</string>
+    <string name="ssh" translatable="false">ssh</string>
+    <string name="github.com" translatable="false">github.com</string>
+    <string name="gitlab.com" translatable="false">gitlab.com</string>
+    <string name="bitbucket.com" translatable="false">bitbucket.com</string>
+    <string name="notabug.org" translatable="false">notabug.org</string>
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="crash_toast_text">MGit error - gathering data to email a crash report</string>
 
     <!-- Intent filters -->
-    <string name="clone_with_mgit">Clone with mGit</string>
+    <string name="clone_with_mgit">Clone with MGit</string>
     <string name="https">https</string>
     <string name="http">http</string>
     <string name="git">git</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -176,4 +176,18 @@
 
     <!-- Crash reporting via ACRA -->
     <string name="crash_toast_text">MGit error - gathering data to email a crash report</string>
+
+    <!-- Intent filters -->
+    <string name="clone_with_mgit">Clone with mGit</string>
+    <string name="https">https</string>
+    <string name="http">http</string>
+    <string name="git">git</string>
+    <string name="git_extension">.git</string>
+    <string name="ending_with_git">.*\\.git</string>
+    <string name="ssh">ssh</string>
+    <string name="github.com">github.com</string>
+    <string name="gitlab.com">gitlab.com</string>
+    <string name="bitbucket.com">bitbucket.com</string>
+    <string name="notabug.org">notabug.org</string>
+    <string name="invalid_url">Invalid URL!</string>
 </resources>


### PR DESCRIPTION
Hi,

With this pr it's possible to intercept intents to open some supported links and clone the repositories.

This is related with #181.

Should I change anything?


![svid_20170927_225800](https://user-images.githubusercontent.com/17972991/30940269-6bf1f628-a3d8-11e7-9b54-28355b7e12f5.gif)

