### PR TITLE
Fix ClassCastException for TAG_MODE

### DIFF
--- a/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
+++ b/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
@@ -88,7 +88,7 @@ public class ViewFileActivity extends SheimiFragmentActivity {
         mFileFragment = new ViewFileFragment();
         mFileFragment.setArguments(b);
         mActivityMode = extras.getShort(TAG_MODE, TAG_MODE_NORMAL);
-        b.putInt(TAG_MODE, mActivityMode);
+        b.putShort(TAG_MODE, mActivityMode);
         getActionBar().setDisplayHomeAsUpEnabled(true);
         setTitle(new File(fileName).getName());
     }


### PR DESCRIPTION
Hi,

when selecting a (text) file inside an existing repository, a warning about wrong types appears in the log output (`ClassCastException`).

Example:

~~~
10-06 17:47:49.003 1571-2461/system_process I/ActivityManager: START u0 {cmp=com.manichord.mgit/me.sheimi.sgit.activities.ViewFileActivity (has extras)} from uid 10085 on display 0
10-06 17:47:49.026 4176-4176/com.manichord.mgit D/Repo: PRESET repo path:/storage/emulated/0/Android/data/com.manichord.mgit/files/repo/mygit
10-06 17:47:49.062 4176-4176/com.manichord.mgit W/System: ClassLoader referenced unknown path: /system/app/Chrome/lib/x86
10-06 17:47:49.062 4176-4176/com.manichord.mgit D/ApplicationLoaders: ignored Vulkan layer search path /system/app/Chrome/lib/x86:/system/app/Chrome/Chrome.apk!/lib/x86:/system/lib:/vendor/lib for namespace 0xac4cb090
10-06 17:47:49.063 4176-4176/com.manichord.mgit I/WebViewFactory: Loading com.android.chrome version 55.0.2883.91 (code 288309112)
10-06 17:47:49.161 4176-4176/com.manichord.mgit I/cr_LibraryLoader: Time to load native libraries: 17 ms (timestamps 15-32)
10-06 17:47:49.161 4176-4176/com.manichord.mgit I/cr_LibraryLoader: Expected native library version number "55.0.2883.91", actual native library version number "55.0.2883.91"
10-06 17:47:49.179 4176-4176/com.manichord.mgit I/cr_LibraryLoader: Expected native library version number "55.0.2883.91", actual native library version number "55.0.2883.91"
10-06 17:47:49.195 4176-4176/com.manichord.mgit I/chromium: [INFO:library_loader_hooks.cc(163)] Chromium logging enabled: level = 0, default verbosity = 0
10-06 17:47:49.213 4176-4176/com.manichord.mgit I/cr_BrowserStartup: Initializing chromium process, singleProcess=true
10-06 17:47:49.407 4176-4176/com.manichord.mgit D/EGL_emulation: eglCreateContext: 0xa45c21a0: maj 2 min 0 rcv 2
10-06 17:47:49.412 4176-4176/com.manichord.mgit D/EGL_emulation: eglMakeCurrent: 0xa45c21a0: ver 2 0 (tinfo 0xa45b5ee0)
10-06 17:47:49.674 4176-4176/com.manichord.mgit W/Bundle: Key mode expected Short but value was a java.lang.Integer.  The default value 0 was returned.
10-06 17:47:49.674 4176-4176/com.manichord.mgit W/Bundle: Attempt to cast generated internal exception:
                                                          java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Short
                                                              at android.os.BaseBundle.getShort(BaseBundle.java:839)
                                                              at android.os.Bundle.getShort(Bundle.java:733)
                                                              at me.sheimi.sgit.fragments.ViewFileFragment.onCreateView(ViewFileFragment.java:57)
                                                              at android.app.Fragment.performCreateView(Fragment.java:2353)
                                                              at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:995)
                                                              at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1171)
                                                              at android.app.BackStackRecord.run(BackStackRecord.java:816)
                                                              at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1578)
                                                              at android.app.FragmentManagerImpl.executePendingTransactions(FragmentManager.java:563)
                                                              at android.support.v13.app.FragmentPagerAdapter.finishUpdate(FragmentPagerAdapter.java:153)
                                                              at android.support.v4.view.ViewPager.populate(ViewPager.java:1268)
                                                              at android.support.v4.view.ViewPager.populate(ViewPager.java:1116)
                                                              at android.support.v4.view.ViewPager.onMeasure(ViewPager.java:1642)
                                                              at android.view.View.measure(View.java:19857)
                                                              at android.widget.RelativeLayout.measureChildHorizontal(RelativeLayout.java:715)
                                                              at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:461)
                                                              at android.view.View.measure(View.java:19857)
                                                              at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6083)
                                                              at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
                                                              at android.view.View.measure(View.java:19857)
                                                              at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6083)
                                                              at com.android.internal.widget.ActionBarOverlayLayout.onMeasure(ActionBarOverlayLayout.java:446)
                                                              at android.view.View.measure(View.java:19857)
                                                              at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6083)
                                                              at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
                                                              at com.android.internal.policy.DecorView.onMeasure(DecorView.java:689)
                                                              at android.view.View.measure(View.java:19857)
                                                              at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2275)
                                                              at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:1366)
                                                              at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1619)
                                                              at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1254)
                                                              at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6337)
                                                              at android.view.Choreographer$CallbackRecord.run(Choreographer.java:874)
                                                              at android.view.Choreographer.doCallbacks(Choreographer.java:686)
                                                              at android.view.Choreographer.doFrame(Choreographer.java:621)
                                                              at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:860)
                                                              at android.os.Handler.handleCallback(Handler.java:751)
                                                              at android.os.Handler.dispatchMessage(Handler.java:95)
                                                              at android.os.Looper.loop(Looper.java:154)
                                                              at android.app.ActivityThread.main(ActivityThread.java:6119)
                                                              at java.lang.reflect.Method.invoke(Native Method)
                                                              at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
                                                              at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
10-06 17:47:49.721 4176-4176/com.manichord.mgit I/cr_Ime: ImeThread is enabled.
10-06 17:47:49.724 4176-4224/com.manichord.mgit W/cr_media: Requires BLUETOOTH permission
10-06 17:47:49.744 4176-4212/com.manichord.mgit D/Repo: PRESET repo path:/storage/emulated/0/Android/data/com.manichord.mgit/files/repo/mygit
10-06 17:47:49.990 4176-4187/com.manichord.mgit I/art: Background partial concurrent mark sweep GC freed 12488(1405KB) AllocSpace objects, 11(284KB) LOS objects, 36% free, 6MB/10MB, paused 186us total 125.590ms
10-06 17:47:50.039 4176-4176/com.manichord.mgit W/art: Attempt to remove non-JNI local reference, dumping thread
10-06 17:47:50.051 4176-4198/com.manichord.mgit D/EGL_emulation: eglMakeCurrent: 0xa45e3240: ver 2 0 (tinfo 0xa45b5dd0)
10-06 17:47:50.255 1571-1623/system_process I/ActivityManager: Displayed com.manichord.mgit/me.sheimi.sgit.activities.ViewFileActivity: +1s240ms

~~~

I tested with current  master (as of commit 0770b43abea9fa6f6128e792b4efaa0cf49576c5).

The reason is that an `int` value is inserted into the bundle for `TAG_MODE`, for which `short` values are expected/used.

This commit fixes that.

I'd be happy if this could be merged or you can provide feedback on the suggestion.

Thanks,
  Michael