### PR TITLE
add play services to update openssl on >API21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     compile libraries.securePreferences
     compile libraries.acra
 
+    compile "com.google.android.gms:play-services-base:11.8.0"
+
     testCompile libraries.junit
     testCompile libraries.robolectric
     testCompile libraries.robolectricShadowSupport

--- a/app/src/debug/java/me/sheimi/sgit/MGitDebugApplication.java
+++ b/app/src/debug/java/me/sheimi/sgit/MGitDebugApplication.java
@@ -3,7 +3,6 @@ package me.sheimi.sgit;
 import android.util.Log;
 
 import com.facebook.stetho.Stetho;
-import com.facebook.stetho.timber.StethoTree;
 
 import timber.log.Timber;
 

--- a/app/src/main/java/me/sheimi/sgit/RepoListActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/RepoListActivity.java
@@ -6,12 +6,18 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ListView;
 import android.widget.SearchView;
 import android.widget.Toast;
+
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.security.ProviderInstaller;
+import com.manichord.mgit.transport.MGitHttpConnectionFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -31,6 +37,7 @@ import me.sheimi.sgit.dialogs.DummyDialogListener;
 import me.sheimi.sgit.dialogs.ImportLocalRepoDialog;
 import me.sheimi.sgit.repo.tasks.repo.CloneTask;
 import me.sheimi.sgit.ssh.PrivateKeyUtils;
+import timber.log.Timber;
 
 public class RepoListActivity extends SheimiFragmentActivity {
 
@@ -43,7 +50,11 @@ public class RepoListActivity extends SheimiFragmentActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         PrivateKeyUtils.migratePrivateKeys();
+
+        initUpdatedSSL();
+
         setContentView(R.layout.activity_main);
         mRepoList = (ListView) findViewById(R.id.repoList);
         mRepoListAdapter = new RepoListAdapter(this);
@@ -204,6 +215,26 @@ public class RepoListActivity extends SheimiFragmentActivity {
 
     public void finish() {
         rawfinish();
+    }
+
+    private void initUpdatedSSL() {
+        try {
+            if (Build.VERSION.SDK_INT < 21) {
+                ProviderInstaller.installIfNeeded(this);
+            }
+        } catch (GooglePlayServicesRepairableException e) {
+            showGooglePlayError(e);
+        } catch (GooglePlayServicesNotAvailableException e) {
+            showGooglePlayError(e);
+        }
+        MGitHttpConnectionFactory.install();
+        Timber.i("Installed custom HTTPS factory");
+    }
+
+    private void showGooglePlayError(Exception e) {
+        Timber.e(e);
+        showMessageDialog(R.string.error_need_play_services_title,
+            getString(R.string.error_need_play_services_message));
     }
 
 }

--- a/app/src/main/res/values/strings_error.xml
+++ b/app/src/main/res/values/strings_error.xml
@@ -23,6 +23,10 @@
 
     <string name="error_rebase_abort_failed_in_reset">Could not abort rebase while resetting repo</string>
 
+    <string name="error_need_play_services_title">Google Play Services Missing</string>
+    <string name="error_need_play_services_message">On Android versions lower than 5.0, Google Play Services are required but not available on this device. MGit will not work with TLSv1.2 Only services such as Gituhub because of this.
+    </string>
+
     <!-- alerts -->
     <string name="alert_too_short_key_size">Keylength is too small (at least 1024 bits for RSA and DSA)</string>
     <string name="alert_too_long_key_size">Keylength is too large</string>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply from: 'dependencies.gradle'
 buildscript {
     apply from: 'dependencies.gradle'
     repositories {
-//        google()
+        google()
         jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
@@ -16,7 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
-//        google()
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
On older devices (pre API 21) its possible that the openssl lib shipped with the device has bugs that prevent it connecting to services like Github which have started enforcing TLSv1.2 *only*.
Adding a dependency on Play Services allows us to easily use the more up to date OpenSSL lib shipped with Play Services.
This along with PR #272 should finally fix #259 