### PR TITLE
check for actionbar before trying to use it

### DIFF
--- a/app/src/main/java/me/sheimi/sgit/activities/explorer/FileExplorerActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/explorer/FileExplorerActivity.java
@@ -41,7 +41,9 @@ public abstract class FileExplorerActivity extends SheimiFragmentActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_file_list);
-        getActionBar().setDisplayHomeAsUpEnabled(true);
+        if (getActionBar() != null) {
+            getActionBar().setDisplayHomeAsUpEnabled(true);
+        }
         mRootFolder = getRootFolder();
         mCurrentDir = mRootFolder;
 


### PR DESCRIPTION
Fixes crash on Android 4.4 when displaying the FileExplorer to set the root folder for local repos via the MGit's user settings.