### PR TITLE
Update the Android Gradle plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
     - extra-android-support
     - extra-android-m2repository
 jdk:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,13 @@ dependencies {
     testCompile libraries.junit
     testCompile libraries.robolectric
     testCompile libraries.robolectricShadowSupport
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 
     kapt "com.android.databinding:compiler:$versions.androidGradlePlugin"
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url 'https://maven.google.com' }
     }
     dependencies {
         classpath gradlePlugins.android
@@ -21,6 +22,7 @@ wrapper {
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 
@@ -28,3 +30,4 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,17 +3,17 @@ ext.versions = [
         name                    : '1.0',
 
         minSdk                  : 16,
-        targetSdk               : 26,
-        compileSdk              : 26,
-        buildTools              : '26.0.2',
+        targetSdk               : 27,
+        compileSdk              : 27,
+        buildTools              : '27.0.3',
 
         kotlin                  : '1.2.31',
 
-        androidGradlePlugin     : '2.3.3',
+        androidGradlePlugin     : '3.1.0',
         dexcountPlugin          : '0.6.1',
         versionsGradlePlugin    : '0.13.0',
 
-        supportLibs             : '25.1.0',
+        supportLibs             : '27.1.1',
         timber                  : '4.5.1',
 
         jcraft                  : '0.1.5.4',
@@ -68,6 +68,7 @@ ext.libraries = [
 def addRepos(RepositoryHandler handler) {
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.google()
 }
 
 ext.addRepos = this.&addRepos

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+
+#This is needed because AAPT2 doesn't liks the drawable attributes set in the styles.xml files.
+android.enableAapt2=false


### PR DESCRIPTION
The `maven url("maven.google.com")` are known and supported by F-Droid's scanner.
There are still issues, but they are worked around by the change in `gradle.properties`.

Fixes #305