### PR TITLE
Improve TLS security

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 *.bat text eol=crlf
 *.java text eol=lf
+*.kt text eol=lf
+*.gradle text eol=lf
 gradlew eol=lf
 *.xml eol=lf
 .git* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.bat text eol=crlf
+*.java text eol=lf
+gradlew eol=lf
+*.xml eol=lf
+.git* text eol=lf

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile libraries.securePreferences
     compile libraries.acra
 
-    compile "org.conscrypt:conscrypt-android:1.0.1"
+    compile "org.conscrypt:conscrypt-android:1.1.0"
 
     testCompile libraries.junit
     testCompile libraries.robolectric

--- a/app/src/main/java/com/manichord/mgit/transport/MGitSSLSocketFactory.java
+++ b/app/src/main/java/com/manichord/mgit/transport/MGitSSLSocketFactory.java
@@ -13,7 +13,7 @@ import javax.net.ssl.SSLSocketFactory;
 public class MGitSSLSocketFactory extends SSLSocketFactory {
 
     private SSLSocketFactory wrappedSSLSocketFactory;
-    public static String[] enabledProtocols = new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"};
+    public static String[] enabledProtocols = new String[] {"TLSv1.2", "TLSv1.1", "TLSv1"};
 
     public MGitSSLSocketFactory(SSLSocketFactory wrapped) {
         wrappedSSLSocketFactory = wrapped;


### PR DESCRIPTION
This updates conscrypt.
Now, TLSv1.2 is used whenever possible, the other versions are only fallbacks.