### PR TITLE
diff color for branch button text light/dark theme

### DIFF
--- a/app/src/main/res/layout/activity_repo_detail_content.xml
+++ b/app/src/main/res/layout/activity_repo_detail_content.xml
@@ -29,7 +29,7 @@
         android:padding="@dimen/branch_label_padding"
         android:text="@string/default_text"
         android:textAlignment="center"
-        android:textColor="@color/branch_name_text"
+        android:textColor="?bt_branch_name_text_color"
         android:textSize="@dimen/branch_label_text_size" />
     <ImageView
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,6 +2,7 @@
 
     <attr name="pager_title_strip_background" format="reference"/>
     <attr name="bt_branch_name_bg" format="reference"/>
+    <attr name="bt_branch_name_text_color" format="reference"/>
     <attr name="mgit_drawer_text_color"  format="reference" />
     <attr name="mgit_drawer_background" format="reference" />
     <attr name="ic_file_fl" format="reference" />

--- a/app/src/main/res/values/styles_sgit.xml
+++ b/app/src/main/res/values/styles_sgit.xml
@@ -34,6 +34,7 @@
         <item name="android:textColor">@android:color/black</item>
         <item name="android:actionBarWidgetTheme">@style/Theme.Sgit.Widget</item>
         <item type="color" name="bt_branch_name_bg">@android:color/white</item>
+        <item type="color" name="bt_branch_name_text_color">@color/branch_name_bg</item>
         <item type="color" name="pager_title_strip_background">@color/branch_name_bg</item>
         <item type="color" name="mgit_drawer_text_color">@android:color/background_dark</item>
         <item type="color" name="mgit_drawer_background">@android:color/background_light</item>

--- a/app/src/main/res/values/styles_sgit_dark.xml
+++ b/app/src/main/res/values/styles_sgit_dark.xml
@@ -24,6 +24,7 @@
         <item name="android:actionMenuTextColor">@android:color/white</item>
         <item name="android:textColor">@android:color/white</item>
         <item type="color" name="bt_branch_name_bg">@android:color/black</item>
+        <item type="color" name="bt_branch_name_text_color">@android:color/white</item>
         <item type="color" name="pager_title_strip_background">@android:color/black</item>
         <item type="color" name="mgit_drawer_text_color">@android:color/white</item>
         <item type="color" name="mgit_drawer_background">@android:color/background_dark</item>


### PR DESCRIPTION
Need to have different colors for the branch button's label text, as just using white makes it invisible in the default light theme.

Fixes: #377 