### PR TITLE
make Stetho logging optional via bool res flag

### DIFF
--- a/app/src/debug/java/me/sheimi/sgit/MGitDebugApplication.java
+++ b/app/src/debug/java/me/sheimi/sgit/MGitDebugApplication.java
@@ -21,14 +21,15 @@ public class MGitDebugApplication extends SGitApplication {
 
         Stetho.initializeWithDefaults(this);
 
-        Timber.plant(new ConfigurableStethoTree(new ConfigurableStethoTree.Configuration.Builder()
-            .showTags(true)
-            .minimumPriority(Log.DEBUG)
-            .build()));
-
-        Log.i(LOGTAG, "Using Stetho console logging");
-
-        Timber.i("Initialised Stetho debugging");
+        if (true == getResources().getBoolean(R.bool.enable_stetho_timber_logging)) {
+            Timber.plant(new ConfigurableStethoTree(new ConfigurableStethoTree.Configuration.Builder()
+                .showTags(true)
+                .minimumPriority(Log.DEBUG)
+                .build()));
+            Log.i(LOGTAG, "Using Stetho console logging");
+        } else {
+            Timber.plant(new Timber.DebugTree());
+        }
+        Timber.i("Initialised Stetho");
     }
-
 }

--- a/app/src/debug/res/values/bools.xml
+++ b/app/src/debug/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_stetho_timber_logging">true</bool>
+</resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_stetho_timber_logging">false</bool>
+</resources>


### PR DESCRIPTION
This actually implements the behaviour of turning on/off Stetho console logcat logging based on a boolean resource as was previously documented in the Javadoc for MGitDebugApplication.

Fixes: #376 