### PR TITLE
Integrate FileProvider to fix crash on Android 7.0+

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -98,7 +98,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="me.sheimi.sgit.fileprovider"
+            android:authorities="com.manichord.mgit.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -96,6 +96,16 @@
                 android:value=".activities.UserSettingsActivity" />
         </activity>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="me.sheimi.sgit.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,7 +118,7 @@
 
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="me.sheimi.sgit.fileprovider"
+            android:authorities="com.manichord.mgit.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,16 @@
                 android:value=".activities.UserSettingsActivity" />
         </activity>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="me.sheimi.sgit.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
@@ -31,7 +31,7 @@ public class ViewFileActivity extends SheimiFragmentActivity {
 
     public static String TAG_FILE_NAME = "file_name";
     public static String TAG_MODE = "mode";
-    public static final String PROVIDER_AUTHORITY = "me.sheimi.sgit.fileprovider";
+    public static final String PROVIDER_AUTHORITY = "com.manichord.mgit.fileprovider";
     public static short TAG_MODE_NORMAL = 0;
     public static short TAG_MODE_SSH_KEY = 1;
     private CommitsFragment mCommitsFragment;

--- a/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
@@ -3,9 +3,11 @@ package me.sheimi.sgit.activities;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.content.FileProvider;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.PagerTitleStrip;
 import android.support.v4.view.ViewPager;
@@ -29,6 +31,7 @@ public class ViewFileActivity extends SheimiFragmentActivity {
 
     public static String TAG_FILE_NAME = "file_name";
     public static String TAG_MODE = "mode";
+    public static final String PROVIDER_AUTHORITY = "me.sheimi.sgit.fileprovider";
     public static short TAG_MODE_NORMAL = 0;
     public static short TAG_MODE_SSH_KEY = 1;
     private CommitsFragment mCommitsFragment;
@@ -213,20 +216,11 @@ public class ViewFileActivity extends SheimiFragmentActivity {
                 if (mActivityMode == TAG_MODE_SSH_KEY) {
                     return true;
                 }
-                Uri uri = Uri.fromFile(mFileFragment.getFile());
-                String mimeType = FsUtils.getMimeType(uri.toString());
-                Intent viewIntent = new Intent(Intent.ACTION_VIEW);
-                Intent editIntent = new Intent(Intent.ACTION_EDIT);
-                viewIntent.setDataAndType(uri, mimeType);
-                editIntent.setDataAndType(uri, mimeType);
-                try {
-                    Intent chooserIntent = Intent.createChooser(viewIntent,
-                            getString(R.string.label_choose_app_to_edit));
-                    chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { editIntent });
-                    startActivity(chooserIntent);
-                    forwardTransition();
-                } catch (ActivityNotFoundException e) {
-                    showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
+                if (Build.VERSION_CODES.N <= Build.VERSION.SDK_INT) {
+                    chooseEditorAndOpenFileForNAndAbove();
+                }
+                else {
+                    chooseEditorAndOpenFileForMAndBelow();
                 }
                 break;
             case R.id.action_edit:
@@ -248,6 +242,38 @@ public class ViewFileActivity extends SheimiFragmentActivity {
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void chooseEditorAndOpenFileForMAndBelow() {
+        Uri uri = Uri.fromFile(mFileFragment.getFile());
+        String mimeType = FsUtils.getMimeType(uri.toString());
+        Intent viewIntent = new Intent(Intent.ACTION_VIEW);
+        Intent editIntent = new Intent(Intent.ACTION_EDIT);
+        viewIntent.setDataAndType(uri, mimeType);
+        editIntent.setDataAndType(uri, mimeType);
+        try {
+            Intent chooserIntent = Intent.createChooser(viewIntent,
+                    getString(R.string.label_choose_app_to_edit));
+            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { editIntent });
+            startActivity(chooserIntent);
+            forwardTransition();
+        } catch (ActivityNotFoundException e) {
+            showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
+        }
+    }
+
+    private void chooseEditorAndOpenFileForNAndAbove() {
+        Uri uri = FileProvider.getUriForFile(this, PROVIDER_AUTHORITY, mFileFragment.getFile());
+        String mimeType = FsUtils.getMimeType(uri.toString());
+        Intent editIntent = new Intent(Intent.ACTION_EDIT);
+        editIntent.setDataAndType(uri, mimeType);
+        editIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        try {
+            startActivity(editIntent);
+            forwardTransition();
+        } catch (ActivityNotFoundException e) {
+            showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
+        }
     }
 
     public void setLanguage(String lang) {

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external" path="/" />
+</paths>


### PR DESCRIPTION
Hi, this is a fix for #319 .

In Android 7.0+, strict file accessing policy is enforced to apps so we cannot simply use `Intent` to open files in external editors. Instead, we need to integrate ContentProvider mechanism.

Google's guideline on this issue is here: https://developer.android.com/reference/android/support/v4/content/FileProvider

This pull-req is a simple adaption of v4.content.FileProvider and supports exposing all `external` storage which I suppose is the correct behavior (and how MGit behaves for Android ~6.0). I kept prior implementation as it was for Android ~6.0 to keep backward compatibility.

Actually, the `<external-path name="external" path="/" />` entry is most likely interpreted as `/storage/emulated/0` (or .../10 for secondary user) so MGit's default storage path; `/storage/emulated/0/Android/data/me.sheimi.sgit/files/repo` is included by default and things will work just fine.