### PR TITLE
fix opening files with external apps

### DIFF
--- a/app/src/main/java/com/manichord/mgit/ViewHelper.kt
+++ b/app/src/main/java/com/manichord/mgit/ViewHelper.kt
@@ -6,5 +6,5 @@ import android.view.inputmethod.InputMethodManager
 
 fun hideKeyboard(context : Context) {
     val inputMethodManager = context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-    inputMethodManager.hideSoftInputFromWindow((context as Activity).currentFocus.windowToken, 0)
+    inputMethodManager.hideSoftInputFromWindow((context as Activity?)?.currentFocus?.windowToken, 0)
 }

--- a/app/src/main/java/me/sheimi/android/utils/FsUtils.java
+++ b/app/src/main/java/me/sheimi/android/utils/FsUtils.java
@@ -16,6 +16,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.support.v4.content.FileProvider;
 import android.webkit.MimeTypeMap;
 
 /**
@@ -25,6 +26,8 @@ public class FsUtils {
 
     public static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat(
             "yyyyMMdd_HHmmss", Locale.getDefault());
+
+    public static final String PROVIDER_AUTHORITY = "com.manichord.mgit.fileprovider";
     public static final String TEMP_DIR = "temp";
     private static final String LOGTAG = FsUtils.class.getSimpleName();
 
@@ -116,23 +119,23 @@ public class FsUtils {
         return getMimeType(Uri.fromFile(file).toString());
     }
 
-    public static void openFile(File file) {
-        openFile(file, null);
+    public static void openFile(SheimiFragmentActivity activity, File file) {
+        //openFile(file, null);
+        startActivityToEditFile(activity, file);
     }
 
-    public static void openFile(File file, String mimeType) {
-        Intent intent = new Intent();
-        intent.setAction(android.content.Intent.ACTION_VIEW);
-        Uri uri = Uri.fromFile(file);
-        if (mimeType == null) {
-            mimeType = getMimeType(uri.toString());
+    private static void startActivityToEditFile(SheimiFragmentActivity activity, File file) {
+        Uri uri = FileProvider.getUriForFile(activity, PROVIDER_AUTHORITY, file);
+        String mimeType = FsUtils.getMimeType(uri.toString());
+        Intent editIntent = new Intent(Intent.ACTION_EDIT);
+        editIntent.setDataAndType(uri, mimeType);
+        editIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        try {
+            activity.startActivity(editIntent);
+            activity.forwardTransition();
+        } catch (ActivityNotFoundException e) {
+            activity.showMessageDialog(R.string.dialog_error_title, activity.getString(R.string.error_no_edit_app));
         }
-        intent.setDataAndType(uri, mimeType);
-        BasicFunctions.getActiveActivity().startActivity(
-                Intent.createChooser(
-                        intent,
-                        BasicFunctions.getActiveActivity().getString(
-                                R.string.label_choose_app_to_open)));
     }
 
     public static void deleteFile(File file) {

--- a/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/ViewFileActivity.java
@@ -1,13 +1,8 @@
 package me.sheimi.sgit.activities;
 
-import android.content.ActivityNotFoundException;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.content.FileProvider;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.PagerTitleStrip;
 import android.support.v4.view.ViewPager;
@@ -31,7 +26,6 @@ public class ViewFileActivity extends SheimiFragmentActivity {
 
     public static String TAG_FILE_NAME = "file_name";
     public static String TAG_MODE = "mode";
-    public static final String PROVIDER_AUTHORITY = "com.manichord.mgit.fileprovider";
     public static short TAG_MODE_NORMAL = 0;
     public static short TAG_MODE_SSH_KEY = 1;
     private CommitsFragment mCommitsFragment;
@@ -216,12 +210,7 @@ public class ViewFileActivity extends SheimiFragmentActivity {
                 if (mActivityMode == TAG_MODE_SSH_KEY) {
                     return true;
                 }
-                if (Build.VERSION_CODES.N <= Build.VERSION.SDK_INT) {
-                    chooseEditorAndOpenFileForNAndAbove();
-                }
-                else {
-                    chooseEditorAndOpenFileForMAndBelow();
-                }
+                FsUtils.openFile(this, mFileFragment.getFile());
                 break;
             case R.id.action_edit:
                 if (mActivityMode == TAG_MODE_SSH_KEY) {
@@ -242,38 +231,6 @@ public class ViewFileActivity extends SheimiFragmentActivity {
                 return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private void chooseEditorAndOpenFileForMAndBelow() {
-        Uri uri = Uri.fromFile(mFileFragment.getFile());
-        String mimeType = FsUtils.getMimeType(uri.toString());
-        Intent viewIntent = new Intent(Intent.ACTION_VIEW);
-        Intent editIntent = new Intent(Intent.ACTION_EDIT);
-        viewIntent.setDataAndType(uri, mimeType);
-        editIntent.setDataAndType(uri, mimeType);
-        try {
-            Intent chooserIntent = Intent.createChooser(viewIntent,
-                    getString(R.string.label_choose_app_to_edit));
-            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] { editIntent });
-            startActivity(chooserIntent);
-            forwardTransition();
-        } catch (ActivityNotFoundException e) {
-            showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
-        }
-    }
-
-    private void chooseEditorAndOpenFileForNAndAbove() {
-        Uri uri = FileProvider.getUriForFile(this, PROVIDER_AUTHORITY, mFileFragment.getFile());
-        String mimeType = FsUtils.getMimeType(uri.toString());
-        Intent editIntent = new Intent(Intent.ACTION_EDIT);
-        editIntent.setDataAndType(uri, mimeType);
-        editIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        try {
-            startActivity(editIntent);
-            forwardTransition();
-        } catch (ActivityNotFoundException e) {
-            showMessageDialog(R.string.dialog_error_title, getString(R.string.error_no_edit_app));
-        }
     }
 
     public void setLanguage(String lang) {

--- a/app/src/main/java/me/sheimi/sgit/fragments/FilesFragment.java
+++ b/app/src/main/java/me/sheimi/sgit/fragments/FilesFragment.java
@@ -97,7 +97,7 @@ public class FilesFragment extends RepoDetailFragment {
                             return;
                         }
                         try {
-                            FsUtils.openFile(file);
+                            FsUtils.openFile(((SheimiFragmentActivity) getActivity()), file);
                         } catch (ActivityNotFoundException e) {
                             Timber.e(e);
                             ((SheimiFragmentActivity)getActivity()).showMessageDialog(R.string.dialog_error_title,


### PR DESCRIPTION
This PR fixes opening binary files with external apps as well as text files that were fixed previously, avoiding having a `FileUriExposedException` thrown on N and newer versions of Android.

In addition there is also a fix for a crashing bug that occurs sometimes when attempting to hide the onscreen keyboard.

Fixes: #432 