### PR TITLE
fix android 10 permissions (workaround)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:icon="@mipmap/ic_launcher"
         android:logo="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name="com.manichord.mgit.repolist.RepoListActivity"
             android:label="@string/app_name" >


### PR DESCRIPTION
 opted out of scoped storage so that external storage can be accessed again on android 10

fixes #542 