### PR TITLE
fix: use correct `user` section name when setting repo config

### DIFF
--- a/app/src/main/java/me/sheimi/sgit/database/models/GitConfig.java
+++ b/app/src/main/java/me/sheimi/sgit/database/models/GitConfig.java
@@ -16,7 +16,7 @@ public class GitConfig {
 
     private final StoredConfig mConfig;
 
-    private final String USER_SECTION = "name";
+    private final String USER_SECTION = "user";
     private final String NAME_SUBSECTION = "name";
     private final String EMAIL_SUBSECTION = "email";
 


### PR DESCRIPTION
fixes #450

if you use a per-repository configuration of the name, the main section
for user config is added as "name" instead of "user".  this means any
user that wants to set the config can't use the "Config" modal and
instead has to edit the raw config file

instead, this updates the section value to be the correct "user"
as defined in the git documentation:

https://git-scm.com/docs/git-config#Documentation/git-config.txt-username