### PR TITLE
Add more places to request access to all files

### DIFF
--- a/app/src/main/java/com/manichord/mgit/repolist/RepoListActivity.java
+++ b/app/src/main/java/com/manichord/mgit/repolist/RepoListActivity.java
@@ -5,16 +5,12 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import androidx.lifecycle.ViewModelProviders;
 
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import androidx.databinding.DataBindingUtil;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
-import android.provider.Settings;
 import androidx.core.view.MenuItemCompat;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -158,21 +154,6 @@ public class RepoListActivity extends SheimiFragmentActivity {
                 showCloneView();
                 return true;
             case R.id.action_import_repo:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !Environment.isExternalStorageManager()) {
-                    showMessageDialog(
-                        R.string.dialog_access_all_files_title,
-                        R.string.dialog_access_all_files_msg,
-                        R.string.label_ok, (dialogInterface, i) -> {
-                            try {
-                                Uri uri = Uri.fromParts("package", getPackageName(), null);
-                                startActivity(new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri));
-                            } catch (ActivityNotFoundException e) {
-                                startActivity(new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION));
-                            }
-                        }
-                    );
-                    return true;
-                }
                 intent = new Intent(this, ImportRepositoryActivity.class);
                 startActivityForResult(intent, REQUEST_IMPORT_REPO);
                 forwardTransition();

--- a/app/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
+++ b/app/src/main/java/me/sheimi/android/activities/SheimiFragmentActivity.java
@@ -2,16 +2,22 @@ package me.sheimi.android.activities;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Environment;
+import android.provider.Settings;
 import android.util.DisplayMetrics;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -114,6 +120,27 @@ public class SheimiFragmentActivity extends AppCompatActivity {
             // Permission is not granted, so request it from user
             ActivityCompat.requestPermissions(this, new String[]{permission}, MGIT_PERMISSIONS_REQUEST);
         }
+    }
+
+    public boolean checkAndRequestAccessAllFilesPermission(int requestCode) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || Environment.isExternalStorageManager()) {
+            return false;
+        }
+        showMessageDialog(
+            R.string.dialog_access_all_files_title,
+            R.string.dialog_access_all_files_msg,
+            R.string.label_ok, (dialog, which) -> {
+                try {
+                    Uri uri = Uri.fromParts("package", getPackageName(), null);
+                    Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, uri);
+                    startActivityForResult(intent, requestCode);
+                } catch (ActivityNotFoundException e) {
+                    Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                    startActivityForResult(intent, requestCode);
+                }
+            }
+        );
+        return true;
     }
 
     /* View Utils Start */

--- a/app/src/main/java/me/sheimi/sgit/activities/explorer/FileExplorerActivity.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/explorer/FileExplorerActivity.java
@@ -1,6 +1,8 @@
 package me.sheimi.sgit.activities.explorer;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.os.Environment;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -13,6 +15,7 @@ import android.widget.TextView;
 import java.io.File;
 import java.io.FileFilter;
 
+import androidx.annotation.Nullable;
 import me.sheimi.android.activities.SheimiFragmentActivity;
 import me.sheimi.android.utils.Profile;
 import me.sheimi.sgit.R;
@@ -21,6 +24,7 @@ import me.sheimi.sgit.adapters.FilesListAdapter;
 public abstract class FileExplorerActivity extends SheimiFragmentActivity {
 
     public static final String RESULT_PATH = "result_path";
+    private static final int RC_ACCESS_ALL_FILES = 123;
 
     private File mRootFolder;
     private File mCurrentDir;
@@ -71,6 +75,17 @@ public abstract class FileExplorerActivity extends SheimiFragmentActivity {
         mFileList.setOnItemClickListener(getOnListItemClickListener());
         mFileList.setOnItemLongClickListener(getOnListItemLongClickListener());
 
+        if (Environment.getExternalStorageDirectory().equals(mRootFolder)) {
+            checkAndRequestAccessAllFilesPermission(RC_ACCESS_ALL_FILES);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RC_ACCESS_ALL_FILES) {
+            mFilesListAdapter.setDir(mRootFolder);
+        }
     }
 
     @Override

--- a/app/src/main/java/me/sheimi/sgit/adapters/RepoListAdapter.java
+++ b/app/src/main/java/me/sheimi/sgit/adapters/RepoListAdapter.java
@@ -163,6 +163,9 @@ public class RepoListAdapter extends ArrayAdapter<Repo> implements
     public void onItemClick(AdapterView<?> adapterView, View view,
             int position, long id) {
         Repo repo = getItem(position);
+        if (repo.isExternal() && mActivity.checkAndRequestAccessAllFilesPermission(0)) {
+            return;
+        }
         Intent intent = new Intent(mActivity, RepoDetailActivity.class);
         intent.putExtra(Repo.TAG, repo);
         mActivity.startActivity(intent);


### PR DESCRIPTION
Add more places where access all files can be granted:

- open FileExplorerActivity for external storage (import SSH key, import repo, set root storage location for repos, etc.),
- open RepoDetailActivity for external repos.