### PR TITLE
Quick Push Action and Add All bug fixed

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -4,7 +4,9 @@
     package="me.sheimi.sgit" >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".MGitDebugApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,9 @@
     android:versionName="1" >
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <application

--- a/app/src/main/java/me/sheimi/android/utils/Profile.java
+++ b/app/src/main/java/me/sheimi/android/utils/Profile.java
@@ -27,6 +27,11 @@ public class Profile {
         return sSharedPreference;
     }
 
+    public static String getQuickPushMsg(Context context) {
+        String key = context.getString(R.string.pre_key_quick_push_commit_msg);
+        return getProfileSharedPreference(context).getString(key, "");
+    }
+
     public static String getUsername(Context context) {
         String userNamePrefKey = context.getString(R.string.pref_key_git_user_name);
         return getProfileSharedPreference(context).getString(userNamePrefKey, "");

--- a/app/src/main/java/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/delegate/RepoOperationDelegate.java
@@ -23,6 +23,7 @@ import me.sheimi.sgit.activities.delegate.actions.NewDirAction;
 import me.sheimi.sgit.activities.delegate.actions.NewFileAction;
 import me.sheimi.sgit.activities.delegate.actions.PullAction;
 import me.sheimi.sgit.activities.delegate.actions.PushAction;
+import me.sheimi.sgit.activities.delegate.actions.QuickPushAction;
 import me.sheimi.sgit.activities.delegate.actions.RawConfigAction;
 import me.sheimi.sgit.activities.delegate.actions.RebaseAction;
 import me.sheimi.sgit.activities.delegate.actions.RemoveRemoteAction;
@@ -53,6 +54,7 @@ public class RepoOperationDelegate {
         mActions.add(new NewBranchAction(mRepo,mActivity));
         mActions.add(new PullAction(mRepo, mActivity));
         mActions.add(new PushAction(mRepo, mActivity));
+        mActions.add(new QuickPushAction(mRepo, mActivity));
         mActions.add(new AddAllAction(mRepo, mActivity));
         mActions.add(new CommitAction(mRepo, mActivity));
         mActions.add(new ResetAction(mRepo, mActivity));

--- a/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/QuickPushAction.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/QuickPushAction.java
@@ -29,22 +29,26 @@ public class QuickPushAction extends RepoAction {
             mActivity.showToastMessage(R.string.alert_plese_set_commit_msg_for_quick_push);
             return;
         }
+
         mActivity.closeOperationDrawer();
 
-        // stageAll, commit, push
+        // stageAll(include new file), commit, push
         AddToStageTask addTask = new AddToStageTask(mRepo, ".") {
             @Override
             protected void onPostExecute(Boolean isSuccess) {
                 super.onPostExecute(isSuccess);
                 //commit
                 CommitChangesTask commitTask = new CommitChangesTask(mRepo,
-                    quickPushMsg, false,
-                    false,
+                    quickPushMsg, false, false,
                     Profile.getUsername(mActivity.getApplicationContext()),
                     Profile.getEmail(mActivity.getApplicationContext()),
                     new AsyncTaskPostCallback() {
                         @Override
                         public void onPostExecute(Boolean isSuccess) {
+                            //   mActivity.reset() is copy from existed code when new CommitChangeTask(),
+                            // idk this line work for what, but it work bad on here, so comment.
+                            // mActivity.reset();
+
                             PushTask pushTask = new PushTask(mRepo,remotes.toArray()[0].toString(),
                                 false,false,
                                 mActivity.new ProgressCallback(R.string.push_msg_init));

--- a/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/QuickPushAction.java
+++ b/app/src/main/java/me/sheimi/sgit/activities/delegate/actions/QuickPushAction.java
@@ -1,0 +1,61 @@
+package me.sheimi.sgit.activities.delegate.actions;
+
+import java.util.Set;
+
+import me.sheimi.android.utils.Profile;
+import me.sheimi.sgit.R;
+import me.sheimi.sgit.activities.RepoDetailActivity;
+import me.sheimi.sgit.database.models.Repo;
+import me.sheimi.sgit.repo.tasks.repo.AddToStageTask;
+import me.sheimi.sgit.repo.tasks.repo.CommitChangesTask;
+import me.sheimi.sgit.repo.tasks.repo.PushTask;
+
+public class QuickPushAction extends RepoAction {
+
+    public QuickPushAction(Repo repo, RepoDetailActivity activity) {
+        super(repo, activity);
+    }
+
+    @Override
+    public void execute() {
+        Set<String> remotes = mRepo.getRemotes();
+        if (remotes == null || remotes.isEmpty()) {
+            mActivity.showToastMessage(R.string.alert_please_add_a_remote);
+            return;
+        }
+
+        String quickPushMsg = Profile.getQuickPushMsg(mActivity.getApplicationContext());
+        if(quickPushMsg==null || quickPushMsg.isEmpty()) {
+            mActivity.showToastMessage(R.string.alert_plese_set_commit_msg_for_quick_push);
+            return;
+        }
+        mActivity.closeOperationDrawer();
+
+        // stageAll, commit, push
+        AddToStageTask addTask = new AddToStageTask(mRepo, ".") {
+            @Override
+            protected void onPostExecute(Boolean isSuccess) {
+                super.onPostExecute(isSuccess);
+                //commit
+                CommitChangesTask commitTask = new CommitChangesTask(mRepo,
+                    quickPushMsg, false,
+                    false,
+                    Profile.getUsername(mActivity.getApplicationContext()),
+                    Profile.getEmail(mActivity.getApplicationContext()),
+                    new AsyncTaskPostCallback() {
+                        @Override
+                        public void onPostExecute(Boolean isSuccess) {
+                            PushTask pushTask = new PushTask(mRepo,remotes.toArray()[0].toString(),
+                                false,false,
+                                mActivity.new ProgressCallback(R.string.push_msg_init));
+                            pushTask.executeTask();
+                        }
+                    });
+                commitTask.executeTask();
+            }
+        };
+
+        addTask.executeTask();
+    }
+
+}

--- a/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/AddToStageTask.java
+++ b/app/src/main/java/me/sheimi/sgit/repo/tasks/repo/AddToStageTask.java
@@ -25,7 +25,14 @@ public class AddToStageTask extends RepoOpTask {
 
     public boolean addToStage() {
         try {
-            mRepo.getGit().add().addFilepattern(mFilePattern).call();
+            //   jGit hasn't a cmd direct add modified/new/deleted files, so if want to add
+            //   those 3 types changed, need a combined call like below.
+            //   check it: https://stackoverflow.com/a/59434085
+
+            //add modified/new files
+            mRepo.getGit().add().setUpdate(false).addFilepattern(mFilePattern).call();
+            //add modified/deleted files
+            mRepo.getGit().add().setUpdate(true).addFilepattern(mFilePattern).call();
         } catch (StopTaskException e) {
             return false;
         } catch (Throwable e) {

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -19,6 +19,7 @@
         <item>Neuer Branch</item>
         <item>Pull</item>
         <item>Push</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Alles zum Staging-Bereich hinzufügen</item>
         <item>Commit</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,6 +165,8 @@
     <string name="preference_send_feedback">Feedback</string>
     <string name="preference_send_feedback_summary">Feedback im GitHub Issue Tracker geben</string>
     <string name="preference_use_theme">Farbschema ändern</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="success_remote_removed">Remote Repository gelöscht</string>
     <string name="preference_manage_ssh_keys_summary">SSH Schlüssel verwalten</string>
     <string name="preference_use_gravatar">Verwenden Sie gravatar Bilder</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -166,7 +166,7 @@
     <string name="preference_send_feedback_summary">Feedback im GitHub Issue Tracker geben</string>
     <string name="preference_use_theme">Farbschema ändern</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="success_remote_removed">Remote Repository gelöscht</string>
     <string name="preference_manage_ssh_keys_summary">SSH Schlüssel verwalten</string>
     <string name="preference_use_gravatar">Verwenden Sie gravatar Bilder</string>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -17,6 +17,7 @@
         <item>Nuevo Ramo</item>
         <item>Tirar</item>
         <item>Empujar</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Anadir todo a stage</item>
         <item>Commit</item>
         <item>Reset (DURO)</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,7 +167,7 @@
     <string name="pref_category_title_security">Security</string>
     <string name="preference_use_theme">Select Colour Theme</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>
     <string name="action_add_private_key">Add Private Key</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,6 +166,8 @@
     <string name="preference_use_gravatar_summary">Load avatar images from gravatar.com</string>
     <string name="pref_category_title_security">Security</string>
     <string name="preference_use_theme">Select Colour Theme</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>
     <string name="action_add_private_key">Add Private Key</string>

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -17,8 +17,9 @@
     </string-array>
     <string-array name="repo_operation_names">
         <item>Nouveau Branche</item>
-        <item>Tirer</item>
-        <item>Pousser</item>
+        <item>Tirer</item>
+        <item>Pousser</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Ajouter tout au stage</item>
         <item>Commit</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -169,7 +169,7 @@
     <string name="pref_category_title_security">Securité</string>
     <string name="preference_use_theme">Selectionner le thème de couleur</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="action_git_profile">Profil Git</string>
     <string name="action_open_in_other_app">Ouvrir dans d\'autres apps</string>
     <string name="action_add_private_key">Ajouter une clé privée</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -168,6 +168,8 @@
     <string name="preference_use_gravatar_summary">Charger des images d\'avatar de gravatar.com</string>
     <string name="pref_category_title_security">Securité</string>
     <string name="preference_use_theme">Selectionner le thème de couleur</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="action_git_profile">Profil Git</string>
     <string name="action_open_in_other_app">Ouvrir dans d\'autres apps</string>
     <string name="action_add_private_key">Ajouter une clé privée</string>

--- a/app/src/main/res/values-iw/arrays.xml
+++ b/app/src/main/res/values-iw/arrays.xml
@@ -18,6 +18,7 @@
     <item>סניף חדש</item>
     <item>משוך</item>
     <item>דחוף</item>
+    <item>Quick Push(Add,Commit,Push)</item>
     <item>הוסף את כולם לשלב</item>
     <item>Commit</item>
     <item>Reset (HARD)</item>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -152,7 +152,7 @@
   <string name="preference_send_feedback_summary">Submit feedback by creating a new issue on GitHub</string>
   <string name="preference_use_theme">Select Colour Theme</string>
   <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-  <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+  <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
   <string name="success_remote_removed">Remote removed</string>
   <string name="preference_manage_ssh_keys_summary">Manage SSH Keys</string>
   <string name="preference_use_gravatar">Use gravatar images</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -151,6 +151,8 @@
   <string name="preference_send_feedback">Feedback</string>
   <string name="preference_send_feedback_summary">Submit feedback by creating a new issue on GitHub</string>
   <string name="preference_use_theme">Select Colour Theme</string>
+  <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+  <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
   <string name="success_remote_removed">Remote removed</string>
   <string name="preference_manage_ssh_keys_summary">Manage SSH Keys</string>
   <string name="preference_use_gravatar">Use gravatar images</string>

--- a/app/src/main/res/values-ja/arrays.xml
+++ b/app/src/main/res/values-ja/arrays.xml
@@ -19,6 +19,7 @@
         <item>新しいブランチ</item>
         <item>プル</item>
         <item>プッシュ</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>すべてステージに追加</item>
         <item>コミット</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -163,6 +163,8 @@
     <string name="preference_send_feedback">フィードバック</string>
     <string name="preference_send_feedback_summary">GitHub に新しいイシューを作成してフィードバックを送信します</string>
     <string name="preference_use_theme">色のテーマを選択</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="success_remote_removed">リモートを削除しました</string>
     <string name="preference_manage_ssh_keys_summary">SSH キーを管理</string>
     <string name="preference_use_gravatar">グラビア画像を使用する</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -164,7 +164,7 @@
     <string name="preference_send_feedback_summary">GitHub に新しいイシューを作成してフィードバックを送信します</string>
     <string name="preference_use_theme">色のテーマを選択</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="success_remote_removed">リモートを削除しました</string>
     <string name="preference_manage_ssh_keys_summary">SSH キーを管理</string>
     <string name="preference_use_gravatar">グラビア画像を使用する</string>

--- a/app/src/main/res/values-ko/arrays.xml
+++ b/app/src/main/res/values-ko/arrays.xml
@@ -17,6 +17,7 @@
         <item>New Branch</item>
         <item>Pull</item>
         <item>Push</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Add all to stage</item>
         <item>Commit</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -153,6 +153,8 @@
     <string name="preference_use_gravatar_summary">Load avatar images from gravatar.com</string>
     <string name="pref_category_title_security">Security</string>
     <string name="preference_use_theme">테마선택</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="action_git_profile">Git 프로필</string>
     <string name="action_open_in_other_app">다른 앱에서 열기</string>
     <string name="action_add_private_key">Private Key 추가</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -154,7 +154,7 @@
     <string name="pref_category_title_security">Security</string>
     <string name="preference_use_theme">테마선택</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="action_git_profile">Git 프로필</string>
     <string name="action_open_in_other_app">다른 앱에서 열기</string>
     <string name="action_add_private_key">Private Key 추가</string>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -17,6 +17,7 @@
         <item>Новая ветвь</item>
         <item>Обновить</item>
         <item>Загрузить</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Добавить все</item>
         <item>Закоммитить</item>
         <item>СБРОС</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -168,6 +168,8 @@
     <string name="preference_use_gravatar_summary">Загрузка аватарок с gravatar.com</string>
     <string name="pref_category_title_security">Безопасность</string>
     <string name="preference_use_theme">Тема</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="action_git_profile">Профиль Git</string>
     <string name="action_open_in_other_app">Открыть в другом приложении</string>
     <string name="action_add_private_key">Добавить приватный ключ</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,7 +169,7 @@
     <string name="pref_category_title_security">Безопасность</string>
     <string name="preference_use_theme">Тема</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="action_git_profile">Профиль Git</string>
     <string name="action_open_in_other_app">Открыть в другом приложении</string>
     <string name="action_add_private_key">Добавить приватный ключ</string>

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -19,9 +19,10 @@
         <item>新的分支</item>
         <item>拉取</item>
         <item>推送</item>
+        <item>快速推送(添加，提交，推送)</item>
         <item>暂存所有</item>
         <item>提交</item>
-        <item>重置（强制）</item>
+        <item>重置（HARD）</item>
         <item>合并</item>
         <item>获取</item>
         <item>衍合</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -171,6 +171,8 @@
     <string name="preference_use_gravatar_summary">从gravatar.com加载头像图片</string>
     <string name="pref_category_title_security">安全</string>
     <string name="preference_use_theme">选择颜色主题</string>
+    <string name="preference_quick_push_commit_msg">为快速推送设置提交信息</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">请为快速推送设置提交信息</string>
     <string name="action_git_profile">Git 配置</string>
     <string name="action_open_in_other_app">在其他应用中打开</string>
     <string name="action_add_private_key">添加私钥</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -154,9 +154,9 @@
 
     <!-- Preferences -->
 
-    <string name="preference_repo_location">repos 的根存储位置</string>
-    <string name="pref_category_title_general">通用</string>
-    <string name="action_select_root_dir">选择作为根文件夹</string>
+    <string name="preference_repo_location">仓库存储目录</string>
+    <string name="pref_category_title_general">常规</string>
+    <string name="action_select_root_dir">选择一个文件夹作为仓库存储目录</string>
     <string name="action_create_new_dir">新建文件夹</string>
     <string name="pref_category_title_git_profile">Git配置</string>
     <string name="preference_git_user_name">用户名</string>
@@ -167,12 +167,12 @@
     <string name="preference_app_version">版本</string>
     <string name="preference_manage_ssh_keys_summary">管理 SSH Keys</string>
     <string name="preference_manage_ssh_keys">SSH Keys</string>
-    <string name="preference_use_gravatar">使用重力图像</string>
+    <string name="preference_use_gravatar">使用gravatar图像</string>
     <string name="preference_use_gravatar_summary">从gravatar.com加载头像图片</string>
     <string name="pref_category_title_security">安全</string>
     <string name="preference_use_theme">选择颜色主题</string>
     <string name="preference_quick_push_commit_msg">为快速推送设置提交信息</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">请为快速推送设置提交信息</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">请先去设置页面为快速推送设置提交信息</string>
     <string name="action_git_profile">Git 配置</string>
     <string name="action_open_in_other_app">在其他应用中打开</string>
     <string name="action_add_private_key">添加私钥</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -19,7 +19,7 @@
         <item>New Branch</item>
         <item>Pull</item>
         <item>Push</item>
-        <item>Quick Push</item>
+        <item>Quick Push(Add,Commit,Push)</item>
         <item>Add all to stage</item>
         <item>Commit</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -19,6 +19,7 @@
         <item>New Branch</item>
         <item>Pull</item>
         <item>Push</item>
+        <item>Quick Push</item>
         <item>Add all to stage</item>
         <item>Commit</item>
         <item>Reset (HARD)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name" translatable="false">MGit</string>
+    <string name="app_name" translatable="false">MGit Mod</string>
     <string name="default_text">Default Text</string>
     <string name="title_clone_repo">Clone Repository</string>
     <string name="preference_file_key" translatable="false">com.manichord.mgit</string>
@@ -176,6 +176,9 @@
     <string name="pref_key_use_gravatar" translatable="false">use.gravatar</string>
     <string name="pref_category_title_security">Security</string>
     <string name="preference_use_theme">Select Colour Theme</string>
+    <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
+    <string name="pre_key_quick_push_commit_msg" translatable="false">quickpush.commitmsg</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
     <string name="pref_key_use_theme_id" translatable="false">color_theme_id</string>
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name" translatable="false">MGit Mod</string>
+    <string name="app_name" translatable="false">MGit</string>
     <string name="default_text">Default Text</string>
     <string name="title_clone_repo">Clone Repository</string>
     <string name="preference_file_key" translatable="false">com.manichord.mgit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,7 +178,7 @@
     <string name="preference_use_theme">Select Colour Theme</string>
     <string name="preference_quick_push_commit_msg">Set commit msg for quick push</string>
     <string name="pre_key_quick_push_commit_msg" translatable="false">quickpush.commitmsg</string>
-    <string name="alert_plese_set_commit_msg_for_quick_push">Plese set commit msg for quick push</string>
+    <string name="alert_plese_set_commit_msg_for_quick_push">Before Quick Push, You must set commit msg for it on Settings</string>
     <string name="pref_key_use_theme_id" translatable="false">color_theme_id</string>
     <string name="action_git_profile">Git Profile</string>
     <string name="action_open_in_other_app">Open in other apps</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -26,7 +26,13 @@
             >
 
         </ListPreference>
-
+        <me.sheimi.sgit.preference.EditTextPreference
+            android:title="@string/preference_quick_push_commit_msg"
+            android:key="@string/pre_key_quick_push_commit_msg"
+            android:summary="%s"
+            android:persistent="true"
+            >
+        </me.sheimi.sgit.preference.EditTextPreference>
         <SwitchPreference
             android:title="@string/preference_eng_lang"
             android:summary="@string/preference_eng_lang_summary"


### PR DESCRIPTION
I make changes below:
- Add a Quick Push Action: one key stage all, commit, push
- Update chinese translation
- Require new permissions MANAGE_EXTERNAL_STORAGE and READ_EXTERNAL_STORAGE for resolve bugging when set Repo-Root-Dir on External storage.(may need manually enable Manage All File permission on system)
- Fixed Add All action does not add deleted files

Quick Push is a combined Action for 3 Actions, StageAll, Commit, Push:
StageAll: it will add modified/new/deleted file to git index.
Commit: commit without Amend or Stage, it only commit with a msg from new settings entry "commit msg for quick push".
Push: default use the remotes list's first element, usually is origin.
