### PR TITLE
bump version for publishing on FDroid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
 
         vectorDrawables.useSupportLibrary = true
 
-        versionCode 227
+        versionCode 240
         versionName "1.7.0"
     }
 


### PR DESCRIPTION
This should allow next version published on FDroid to overwrite discontinued version from Google Play.