### PR TITLE
Remove google & add APK download w/ image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ MGit is a Git client Android App.
 
 This is a continuation of [the SGit project](https://github.com/sheimi/SGit).
 
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png"
-      alt="Get it on Google Play"
-      height="80">](https://play.google.com/store/apps/details?id=com.manichord.mgit)
 [<img src="https://f-droid.org/badge/get-it-on.png"
       alt="Get it on F-Droid"
       height="80">](https://f-droid.org/packages/com.manichord.mgit)


### PR DESCRIPTION
I removed this because when you do install from the playstore, you open the app to say it you need to install it from F-Droid.

so I added the most current url for the apk download as a option and added a image for it.